### PR TITLE
Use kube-applier with CodeCommit to create cluster resources.

### DIFF
--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 
-mkdir -p ./output
+set -euo pipefail
+
+repo_url="${1}"
+
+rm -rf /tmp/gsp-base
+mkdir -p /tmp/gsp-base
 
 helm template \
-  --output-dir ./output \
+  --output-dir /tmp/gsp-base \
   --name gsp-base \
+  --namespace gsp-base \
   --values values.yaml \
   ../../../charts/gsp-base/charts/base
+
+cd /tmp/gsp-base
+git init .
+git config --local credential.helper '!aws codecommit credential-helper $@'
+git config --local credential.UseHttpPath true
+git remote add origin "${repo_url}"
+git add .
+git commit -m "Initial commit by cluster initialisation"
+git push -f origin master

--- a/terraform/modules/codecommit-kube-applier/data/kube-applier.yaml
+++ b/terraform/modules/codecommit-kube-applier/data/kube-applier.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+ name: kube-applier
+ namespace: ${namespace}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-applier
+  namespace: ${namespace}
+subjects:
+- kind: ServiceAccount
+  name: kube-applier
+  namespace: ${namespace}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "kube-applier"
+  namespace: "${namespace}"
+  labels:
+    app: "kube-applier"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kube-applier"
+  template:
+    metadata:
+      labels:
+        app: "kube-applier"
+    spec:
+      serviceAccountName: kube-applier
+      containers:
+        - name: "kube-applier"
+          command:
+            - "/kube-applier"
+          env:
+            - name: "REPO_PATH"
+              value: "/k8s/resources"
+            - name: "LISTEN_PORT"
+              value: "2020"
+          image: "govsvc/kube-applier:0.0.1541676847"
+          ports:
+            - containerPort: 2020
+          volumeMounts:
+            - name: "git-repo"
+              mountPath: "/k8s"
+        - name: "aws-git-sync"
+          command:
+            - "/git-sync"
+          env:
+            - name: "GIT_SYNC_REPO"
+              value: "${git_repo}"
+            - name: "GIT_SYNC_DEST"
+              value: "resources"
+          image: "govsvc/aws-git-sync:0.0.1541608150"
+          ports:
+            - containerPort: 2020
+          volumeMounts:
+            - name: "git-repo"
+              mountPath: "/git"
+      volumes:
+        - name: "git-repo"
+          emptyDir: {}
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "kube-applier"
+  namespace: "${namespace}"
+spec:
+  ports:
+    - name: "service"
+      port: 80
+      targetPort: 2020
+  selector:
+    app: "kube-applier"

--- a/terraform/modules/codecommit-kube-applier/main.tf
+++ b/terraform/modules/codecommit-kube-applier/main.tf
@@ -1,0 +1,22 @@
+resource "aws_codecommit_repository" "repo" {
+  repository_name = "${var.repository_name}"
+  description     = "${var.repository_description}"
+}
+
+data "template_file" "kube-applier-yaml" {
+    template = "${file("${path.module}/data/kube-applier.yaml")}"
+
+    vars {
+        git_repo = "${aws_codecommit_repository.repo.clone_url_http}"
+        namespace = "${var.namespace}"
+    }
+}
+
+resource "local_file" "kube-applier-yaml" {
+    filename = "kube-applier.yaml"
+    content = "${data.template_file.kube-applier-yaml.rendered}"
+}
+
+output "repo_url" {
+    value = "${aws_codecommit_repository.repo.clone_url_http}"
+}

--- a/terraform/modules/codecommit-kube-applier/variables.tf
+++ b/terraform/modules/codecommit-kube-applier/variables.tf
@@ -1,0 +1,11 @@
+variable "repository_name" {
+    type = "string"
+}
+
+variable "repository_description" {
+    type = "string"
+}
+
+variable "namespace" {
+    type = "string"
+}

--- a/terraform/modules/gsp-cluster/main.tf
+++ b/terraform/modules/gsp-cluster/main.tf
@@ -18,6 +18,10 @@ variable "concourse_main_password" {
     type = "string"
 }
 
+variable "codecommit_url" {
+    type = "string"
+}
+
 module "cluster" {
   source = "git::https://github.com/alphagov/gsp-typhoon//aws/container-linux/kubernetes?ref=gsp"
 
@@ -59,6 +63,6 @@ resource "local_file" "values_yaml" {
     content = "${data.template_file.values_yaml.rendered}"
 
     provisioner "local-exec" {
-        command = "../../../scripts/render.sh"
+        command = "../../../scripts/render.sh \"${var.codecommit_url}\""
     }
 }

--- a/terraform/templates/cluster.tf
+++ b/terraform/templates/cluster.tf
@@ -56,4 +56,14 @@ module "cluster" {
   ssh_authorized_key = "(PUBLIC_SSH_KEY)"
 
   concourse_main_password = "${var.concourse_password}"
+
+  codecommit_url = "${module.gsp-base-applier.repo_url}"
+}
+
+module "gsp-base-applier" {
+  source = "../../modules/codecommit-kube-applier"
+
+  repository_name = "(CLUSTER_NAME).(ZONE_NAME).gsp-base"
+  repository_description = "State of the gsp-base world!"
+  namespace = "gsp-base"
 }


### PR DESCRIPTION
The "gsp-base" chart is now rendered and commited to a CodeCommit repo,
created as part of the terraform module. kube-applier is polling the repo
and applying the state accordingly.

Still to do: automate the "kubectly apply" for the kube-applier.