### PR TITLE
Add initial cluster for Observe staging.

### DIFF
--- a/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
@@ -1,0 +1,69 @@
+provider "aws" {
+  region  = "eu-west-2"
+  version = "~> 1.41"
+  alias   = "default"
+}
+
+provider "local" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "gds-re-managed-observe-staging-terraform-state"
+    region = "eu-west-2"
+    key    = "cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tfstate"
+  }
+}
+
+variable "concourse_password" {
+  description = "Concourse `main` user password"
+}
+
+module "cluster" {
+  source = "../../modules/gsp-cluster"
+
+  providers = {
+    aws      = "aws.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+  }
+
+  # AWS
+  cluster_name = "cluster"
+  zone_name    = "re-managed-observe-staging.aws.ext.govsvc.uk"
+  zone_id      = "ZQQE7MLQRG73Z"
+
+  # configuration
+  ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcM1gMH937SSS+gyXBeC4Xbi5Q9JU5E/zOQ8qmEVKJrDpwCzkkt/7amVSFaeYooLDsrjGxBBgcLadoQ0z33GvDzS5D2a8tZWxtrQAvN4o4B2QSksq54ZCte/j8QjLbgrRbpt0WNScuhZiW7NVmbhqfSZORYNW+FtGp24HIRpazLHH5y+36n8YD8liTWELG0ckiUO4JEKs58u6fPOFDQ+GKeuKxIoQEOngG2nOmSpYABo6KJujZ3KH403i7B1FCf3Aao2gXUkj7Oa79YUprDDF0yw5fXsSD0aF8VbKbySkxErBgAwww+bT/UJPdU0udt+T4jbKFkgedYU5pGnBKEOKb0RAZhb1Cecis82jhNxYP5No9TtE/2ZJjjAz6UtPQjrTlFmXNkNvQqvINY/OVCnsMfOdXopOuLdzlGNrkvIvjmiZQhOWHrNuKkQuQG9HCsywVt7g9xrpfsbMpyVAJnGJIv6yn4WcfJmVWmAXY0uzXiY6fyF7d+42EvXrm5jcJG6IBQsTtBj+X+quu0aFA+pfzMFgKGIJon3PX/fEECiu55ATQRYqIlm0xZlbG9wA98TRSuc0wCkUIqVnIo4QZbghAdWBneLpF++8m+65XxdRaCdmy6XjKV8H5NKEe/k1FNTQiWkx4I/TnkggGStfkl8HFmf1lxV8Mh5dwcf2xjOatyw== cluster.re-managed-observe-staging.aws.ext.govsvc.uk"
+
+  concourse_main_password = "${var.concourse_password}"
+
+  codecommit_url = "${module.gsp-base-applier.repo_url}"
+}
+
+module "gsp-base-applier" {
+  source = "../../modules/codecommit-kube-applier"
+
+  repository_name        = "cluster.re-managed-observe-staging.aws.ext.govsvc.uk.gsp-base"
+  repository_description = "State of the gsp-base world!"
+  namespace              = "gsp-base"
+}

--- a/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/kube-applier/gsp-base.yaml
+++ b/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/kube-applier/gsp-base.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gsp-base
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+ name: gsp-base-kube-applier
+ namespace: gsp-base
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gsp-base-kube-applier
+  namespace: gsp-base
+subjects:
+- kind: ServiceAccount
+  name: gsp-base-kube-applier
+  namespace: gsp-base
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "gsp-base-kube-applier"
+  namespace: "gsp-base"
+  labels:
+    app: "gsp-base-kube-applier"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "gsp-base-kube-applier"
+  template:
+    metadata:
+      labels:
+        app: "gsp-base-kube-applier"
+    spec:
+      serviceAccountName: gsp-base-kube-applier
+      containers:
+        - name: "gsp-base-kube-applier"
+          command:
+            - "/kube-applier"
+          env:
+            - name: "REPO_PATH"
+              value: "/k8s/resources"
+            - name: "LISTEN_PORT"
+              value: "2020"
+          image: "govsvc/kube-applier:0.0.1541676847"
+          ports:
+            - containerPort: 2020
+          volumeMounts:
+            - name: "git-repo"
+              mountPath: "/k8s"
+        - name: "aws-git-sync"
+          command:
+            - "/git-sync"
+          env:
+            - name: "GIT_SYNC_REPO"
+              value: "https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/cluster.re-managed-observe-staging.aws.ext.govsvc.uk.gsp-base"
+            - name: "GIT_SYNC_DEST"
+              value: "resources"
+          image: "govsvc/aws-git-sync:0.0.1541608150"
+          ports:
+            - containerPort: 2020
+          volumeMounts:
+            - name: "git-repo"
+              mountPath: "/git"
+      volumes:
+        - name: "git-repo"
+          emptyDir: {}
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "gsp-base-kube-applier"
+  namespace: "gsp-base"
+spec:
+  ports:
+    - name: "service"
+      port: 80
+      targetPort: 2020
+  selector:
+    app: "gsp-base-kube-applier"

--- a/terraform/templates/cluster.tf
+++ b/terraform/templates/cluster.tf
@@ -26,7 +26,7 @@ provider "tls" {
 
 terraform {
   backend "s3" {
-    bucket = "gds-re-(AWS_ACCOUNT_NAME)-terraform-state"
+    bucket = "gds-(AWS_ACCOUNT_NAME)-terraform-state"
     region = "eu-west-2"
     key    = "(CLUSTER_NAME).(AWS_ACCOUNT_NAME).(CLOUD).(SYSTEM_DOMAIN)/cluster.tfstate"
   }


### PR DESCRIPTION
Initial kubernetes cluster for Observe's staging is up and running.

Also fixed the template to stop duplication of terms in the generated names.

Pair: @blairboy362 @samcrang 