### PR TITLE
Add IAM authentication for kubectl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ## Prerequisites
 
 - Docker installed and running locally
+- aws cli
+- aws-iam-authenticator (`go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator`)
 
 ## How to register a new cluster
 
@@ -71,14 +73,13 @@
 
 1. Test the connection to Kubernetes by executing the following:
     ```
-    export KUBECONFIG="$(pwd)/bootkube-assets/auth/kubeconfig"
-    kubectl get all --all-namespaces
+    cp $(pwd)/bootkube-assets/auth/user-config ./kubeconfig
+    export KUBECONFIG="$(pwd)/kubeconfig"
+    aws-vault exec run-production -- kubectl get all --all-namespaces
     ```
 1. Add kube-applier to the cluster:
    ```
-    kubectl apply -Rf kube-applier/
+    aws-vault exec run-production -- kubectl apply -Rf kube-applier/
    ```
-1. Share the
-   `terraform/clusters/cluster1.gds-re-run-sandbox.aws.ext.govsvc.uk/bootkube-assets/auth/kubeconfig`
 
-1. Commit and Push new `cluster.tf` and the `kube-applier` yaml files file to keep the record.
+1. Commit and Push new `cluster.tf`, `kubeconfig`, and `kube-applier` yaml files to keep the record.

--- a/terraform/modules/gsp-cluster/main.tf
+++ b/terraform/modules/gsp-cluster/main.tf
@@ -22,6 +22,10 @@ variable "codecommit_url" {
   type = "string"
 }
 
+variable "admin_role_arns" {
+  type = "list"
+}
+
 module "cluster" {
   source = "git::https://github.com/alphagov/gsp-typhoon//aws/container-linux/kubernetes?ref=gsp"
 
@@ -37,6 +41,9 @@ module "cluster" {
   # optional
   worker_count = 2
   worker_type  = "t2.medium"
+
+  cluster_id = "${var.cluster_name}.${var.zone_name}"
+  admin_role_arns = "${var.admin_role_arns}"
 }
 
 # needed until externalDNS starts to work

--- a/terraform/templates/cluster.tf
+++ b/terraform/templates/cluster.tf
@@ -36,6 +36,8 @@ variable "concourse_password" {
   description = "Concourse `main` user password"
 }
 
+data "aws_caller_identity" "current" {}
+
 module "cluster" {
   source = "../../modules/gsp-cluster"
 
@@ -58,6 +60,8 @@ module "cluster" {
   concourse_main_password = "${var.concourse_password}"
 
   codecommit_url = "${module.gsp-base-applier.repo_url}"
+
+  admin_role_arns = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
 }
 
 module "gsp-base-applier" {


### PR DESCRIPTION
Send the necessary variables through to terraform-render-bootkube (via
typhoon) to correctly configure IAM authentication in the cluster. It also
creates a user-config kubeconfig file that is configured to connect to it.

- [x] Merge https://github.com/alphagov/gsp-typhoon/pull/1
- [x] Update the bootkube reference in terraform/modules/gsp-cluster/main.tf to point at `gsp` instead of `iam_auth`

Solo: @blairboy362 