### PR TITLE
Move base to kube system

### DIFF
--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -10,7 +10,7 @@ mkdir -p /tmp/gsp-base
 helm template \
   --output-dir /tmp/gsp-base \
   --name gsp-base \
-  --namespace gsp-base \
+  --namespace kube-system \
   --values values.yaml \
   ../../../charts/gsp-base/charts/base
 

--- a/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -57,15 +57,15 @@ module "cluster" {
 
   concourse_main_password = "${var.concourse_password}"
 
-  codecommit_url = "${module.gsp-base-applier.repo_url}"
+  codecommit_url = "${module.kube-system-applier.repo_url}"
 }
 
-module "gsp-base-applier" {
+module "kube-system-applier" {
   source = "../../modules/codecommit-kube-applier"
 
-  repository_name        = "rafalp.run-sandbox.aws.ext.govsvc.uk.gsp-base"
-  repository_description = "State of the gsp-base world!"
-  namespace              = "gsp-base"
+  repository_name        = "rafalp.run-sandbox.aws.ext.govsvc.uk.kube-system"
+  repository_description = "State of the kube-system world!"
+  namespace              = "kube-system"
 }
 
 module "design-applier" {

--- a/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/kube-applier/kube-system.yaml
+++ b/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/kube-applier/kube-system.yaml
@@ -2,23 +2,23 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gsp-base
+  name: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
- name: gsp-base-kube-applier
- namespace: gsp-base
+ name: kube-system-kube-applier
+ namespace: kube-system
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gsp-base-kube-applier
-  namespace: gsp-base
+  name: kube-system-kube-applier
+  namespace: kube-system
 subjects:
 - kind: ServiceAccount
-  name: gsp-base-kube-applier
-  namespace: gsp-base
+  name: kube-system-kube-applier
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: cluster-admin
@@ -27,23 +27,23 @@ roleRef:
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
-  name: "gsp-base-kube-applier"
-  namespace: "gsp-base"
+  name: "kube-system-kube-applier"
+  namespace: "kube-system"
   labels:
-    app: "gsp-base-kube-applier"
+    app: "kube-system-kube-applier"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "gsp-base-kube-applier"
+      app: "kube-system-kube-applier"
   template:
     metadata:
       labels:
-        app: "gsp-base-kube-applier"
+        app: "kube-system-kube-applier"
     spec:
-      serviceAccountName: gsp-base-kube-applier
+      serviceAccountName: kube-system-kube-applier
       containers:
-        - name: "gsp-base-kube-applier"
+        - name: "kube-system-kube-applier"
           command:
             - "/kube-applier"
           env:
@@ -62,7 +62,7 @@ spec:
             - "/git-sync"
           env:
             - name: "GIT_SYNC_REPO"
-              value: "https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/rafalp.run-sandbox.aws.ext.govsvc.uk.gsp-base"
+              value: "https://git-codecommit.eu-west-2.amazonaws.com/v1/repos/rafalp.run-sandbox.aws.ext.govsvc.uk.kube-system"
             - name: "GIT_SYNC_DEST"
               value: "resources"
           image: "govsvc/aws-git-sync:0.0.1541608150"
@@ -78,12 +78,12 @@ spec:
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  name: "gsp-base-kube-applier"
-  namespace: "gsp-base"
+  name: "kube-system-kube-applier"
+  namespace: "kube-system"
 spec:
   ports:
     - name: "service"
       port: 80
       targetPort: 2020
   selector:
-    app: "gsp-base-kube-applier"
+    app: "kube-system-kube-applier"

--- a/terraform/modules/gsp-cluster/data/values.yaml
+++ b/terraform/modules/gsp-cluster/data/values.yaml
@@ -20,3 +20,5 @@ concourse:
       auth:
         mainTeam:
           localUser: "${main_username}"
+kube-dashboard:
+  fullnameOverride: kubernetes-dashboard

--- a/terraform/templates/cluster.tf
+++ b/terraform/templates/cluster.tf
@@ -57,13 +57,13 @@ module "cluster" {
 
   concourse_main_password = "${var.concourse_password}"
 
-  codecommit_url = "${module.gsp-base-applier.repo_url}"
+  codecommit_url = "${module.kube-system-applier.repo_url}"
 }
 
-module "gsp-base-applier" {
+module "kube-system-applier" {
   source = "../../modules/codecommit-kube-applier"
 
-  repository_name        = "(CLUSTER_NAME).(ZONE_NAME).gsp-base"
-  repository_description = "State of the gsp-base world!"
-  namespace              = "gsp-base"
+  repository_name        = "(CLUSTER_NAME).(ZONE_NAME).kube-system"
+  repository_description = "State of the kube-system world!"
+  namespace              = "kube-system"
 }


### PR DESCRIPTION
## What

Most of the tools we're planning on delivering to all of the clusters,
will require some sort of super powers assigned. This is usually solved
by the `kube-system` namespace and in fact is hardcoded in some places.

This only leaves us with concourse which is the odd one out... We don't
feel confident nor excited about its placement.

We'd like to make sure, the dashboard is accessible through the
`kubectl proxy` behaviour. This requires a specific service name to be
provided.

## How to review

- Update or use Rafal's cluster
- Deploy the cluster
- Run: `k apply -f kube-applier/kube-system.yaml`
- Wait indefinite {_insert troll face_}
- Run: `k proxy`
- Run something like: `k get secrets -n kube-system` and then `k get secrets -n kube-system kubernetes-dashboard-token-UNIQUE -o jsonpath="{.data.token}" | base64 -D | pbcopy`
- Visit `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`

## Before merge

Make sure the submodule is pointing at the master branch... Currently points at the alphagov/gsp-base#3