### PR TITLE
Workaround the 64 byte limit for Common Names

### DIFF
--- a/terraform/modules/gsp-cluster/data/values.yaml
+++ b/terraform/modules/gsp-cluster/data/values.yaml
@@ -9,9 +9,11 @@ concourse:
   web:
     ingress:
       hosts:
+      - c.${cluster_domain}
       - concourse.${cluster_domain}
       tls:
       - hosts:
+        - c.${cluster_domain}
         - concourse.${cluster_domain}
         secretName: concourse-tls-cert
   concourse:


### PR DESCRIPTION
There is a 64 byte limit for a Common Name (CN). This means that a
certificate will fail to be issued for a cluster that has a cluster
that, for example, looks like the following:

```
concourse.cluster.re-managed-observe-production.aws.ext.govsvc.uk
```

We can work around this by setting the first thing in the list of hosts
to be a host that is more likely to be under this 64 byte limit. Other
hosts will be in the certificate's SubjectAltName (SAN) field which
don't have this length limit.