### PR TITLE
Concourse auth

### DIFF
--- a/scripts/create_cluster_config.sh
+++ b/scripts/create_cluster_config.sh
@@ -48,10 +48,6 @@ sed "s/(CLOUD)/${CLOUD}/g" | \
 sed "s/(SYSTEM_DOMAIN)/${SYSTEM_DOMAIN}/g" \
   > "${dir}/cluster.tf"
 
-cat terraform/templates/secrets.tfvars | \
-sed "s/(MAIN_PASSWORD)/${MAIN_PASSWORD}/g" \
-  > "${dir}/secrets.tfvars"
-
 echo "cluster file: Created!"
 echo "You can continue by changing directory to:"
 echo "${dir}"

--- a/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/rafalp.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -32,10 +32,6 @@ terraform {
   }
 }
 
-variable "concourse_password" {
-  description = "Concourse `main` user password"
-}
-
 module "cluster" {
   source = "../../modules/gsp-cluster"
 
@@ -54,8 +50,6 @@ module "cluster" {
 
   # configuration
   ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDm1xKMnwydS4TNtmEhCei6O9Zvxn7wVgkfhe6/nCfie/Ba82x52AAsMWONpuv54Acb6fcSeBAYpv68+3a94eg5fGDj39NvN5NBiPzl/OjwhANfX+P+8ax2eqNz9nBWJPpSAbu1fagTOqLQMqcsKwljJWhM2fGmG7jQMF806BEssCDtVcmF8MRjckhEnhOdKaiqbWYFHQXVAzgzgEQnaKkAq0H4IllopIOba431WlG1TFySnzUWI5k3Ep7He96L3J6dnt2lh0NfoGp1Kb05UEe71nBMS0okC1Rk1zDm7upNonVvBmo4S+1Aw8W+PEu16EH8h8kgfH0gPIqM1y1tYwibm8f8YkMyATA7fIQfmDMujborDRwi3JUI2d0I+nQTfT4xUfZEmh/PvHjegxvZ/dlp+up8fKVAY0ZSawTPhUapuBZaFn3kUjZbT6qSynlSObo6CqhHgPbkWkbIboXEhhYjx/Pgkm0E+vTI3Aq4amr8RXCH9J6/OmnZcTkGRIbC2rvY6W4OeqsrgGE9peB811YT5qfKx7eUNHGryS8hw0nNbLq7cRrfeMca9ddfH4YtQE0tX/IdYgMs1x89+yO4Pj8FsuCjQp7DFlzWKZgGPc+gnoYZz4aNeK3jBrvWF3HAQrCFkL04CjJJvhcGApfNgh42RoADqJOEyqGTH++radeAeQ== rafalp.run-sandbox.aws.ext.govsvc.uk"
-
-  concourse_main_password = "${var.concourse_password}"
 
   codecommit_url = "${module.gsp-base-applier.repo_url}"
 }

--- a/terraform/modules/gsp-cluster/data/values.yaml
+++ b/terraform/modules/gsp-cluster/data/values.yaml
@@ -6,19 +6,8 @@ nginx-ingress:
 concourse:
   secrets:
     localUsers: ${main_username}:${main_password}
-  web:
-    ingress:
-      hosts:
-      - c.${cluster_domain}
-      - concourse.${cluster_domain}
-      tls:
-      - hosts:
-        - c.${cluster_domain}
-        - concourse.${cluster_domain}
-        secretName: concourse-tls-cert
   concourse:
     web:
-      externalUrl: https://concourse.${cluster_domain}/
       auth:
         mainTeam:
           localUser: "${main_username}"

--- a/terraform/modules/gsp-cluster/main.tf
+++ b/terraform/modules/gsp-cluster/main.tf
@@ -14,10 +14,6 @@ variable "ssh_authorized_key" {
   type = "string"
 }
 
-variable "concourse_main_password" {
-  type = "string"
-}
-
 variable "codecommit_url" {
   type = "string"
 }
@@ -61,7 +57,7 @@ data "template_file" "values_yaml" {
   vars {
     cluster_domain = "${var.cluster_name}.${var.zone_name}"
     main_username  = "admin"
-    main_password  = "${var.concourse_main_password}"
+    main_password  = "password"
   }
 }
 

--- a/terraform/templates/secrets.tfvars
+++ b/terraform/templates/secrets.tfvars
@@ -1,1 +1,0 @@
-concourse_password = "(MAIN_PASSWORD)"


### PR DESCRIPTION
## What

We'd like to restrict the access to concourse by default. In order to
achieve that, we need to get rid of the defaults provided by our base
chart.

This will leave our tenants with ability to `kubectl proxy` || `kubectl
port-forwarding` which is a desirable way for safety keeping.

## How to review

- Run `terraform apply`
- Run `kubectl apply -f kube-applier/gsp-base.yaml`
- Wait for the changes to be applied (Concourse to run)
- Follow the instructions in alphagov/gsp-team-manual#11

## Before merge

Make sure the `TMP` commit is pointing to the master branch of `gsp-base` - after merging alphagov/gsp-base#4.