### PR TITLE
Restrict Kubernetes API access

### DIFF
--- a/terraform/modules/gsp-cluster/main.tf
+++ b/terraform/modules/gsp-cluster/main.tf
@@ -37,7 +37,7 @@ variable "admin_role_arns" {
 }
 
 module "cluster" {
-  source = "git::https://github.com/alphagov/gsp-typhoon//aws/container-linux/kubernetes?ref=gsp"
+  source = "git::https://github.com/alphagov/gsp-typhoon//aws/container-linux/kubernetes?ref=restrict-api-access-2"
 
   # AWS
   cluster_name = "${var.cluster_name}"


### PR DESCRIPTION
## What

We're introducing the possibility to whitelist the IPs that will be allowed to interact with Kubernetes API. It will default to the list of Office IPs and due to it's living in the terraform module, it should apply to all of the cluster upon next `terraform apply`.

## How to review

- Spin up the cluster
- Attempt to access it from an outside-of-office IP
- Attempt to access it from an in-office IP

## Before merge

We need to clean up the commit history, including removing the `TMP` commit - to be done after alphagov/gsp-typhoon#2 has been merged.