### PR TITLE
Use the canary updater.

### DIFF
--- a/scripts/initialise_canary_helm_codecommit.sh
+++ b/scripts/initialise_canary_helm_codecommit.sh
@@ -30,10 +30,10 @@ then
   exit 0
 fi
 
-git checkout -b master --track source/master
+git checkout -b add-updater --track source/add-updater
 
 # update the embedded timestamp
 sed -i -E -e "s/(chartCommitTimestamp: )\"[0-9]+\"/\1\"$(date +%s)\"/g" charts/gsp-canary/values.yaml
 git add charts/gsp-canary/values.yaml
 git commit -m "Initial timestamp update."
-git push --force destination master
+git push --force destination add-updater

--- a/terraform/modules/canary/main.tf
+++ b/terraform/modules/canary/main.tf
@@ -16,6 +16,10 @@ module "gsp-canary-release" {
 
   namespace  = "gsp-canary"
   chart_git  = "${aws_codecommit_repository.canary.clone_url_http}"
-  chart_ref  = "master"
+  chart_ref  = "add-updater"
   chart_path = "charts/gsp-canary"
+  values = <<EOF
+    updater:
+      helmChartRepoUrl: ${aws_codecommit_repository.canary.clone_url_http}
+EOF
 }

--- a/terraform/modules/github-flux/data/helm-release.yaml
+++ b/terraform/modules/github-flux/data/helm-release.yaml
@@ -10,4 +10,4 @@ spec:
     ref: "${chart_ref}"
     path: "${chart_path}"
   values:
-    foo: bar # unused/arbitary, but must be at least one "value" or this breaks
+${values}

--- a/terraform/modules/github-flux/main.tf
+++ b/terraform/modules/github-flux/main.tf
@@ -32,6 +32,7 @@ data "template_file" "helm-release" {
     chart_git  = "${var.chart_git}"
     chart_ref  = "${var.chart_ref}"
     chart_path = "${var.chart_path}"
+    values     = "${var.values}"
   }
 }
 

--- a/terraform/modules/github-flux/variables.tf
+++ b/terraform/modules/github-flux/variables.tf
@@ -23,3 +23,9 @@ variable "addons_dir" {
     type = "string"
     default = "addons"
 }
+
+variable "values" {
+    description = "embedded yaml to pass to the helm resource for flux helm operator. Whitespace is important"
+    type = "string"
+    default = "    foo: bar # unused/arbitary, but must be at least one value or this breaks"
+}

--- a/terraform/templates/cluster.tf
+++ b/terraform/templates/cluster.tf
@@ -65,6 +65,15 @@ module "gsp-base-flux-helm" {
   chart_path = "charts/base"
 }
 
+module "gsp-monitoring-release" {
+  source = "../../modules/github-flux"
+
+  namespace  = "monitoring-system"
+  chart_git  = "https://github.com/alphagov/gsp-monitoring.git"
+  chart_ref  = "master"
+  chart_path = "monitoring"
+}
+
 module "gsp-canary" {
   source     = "../../modules/canary"
   cluster_id = "(CLUSTER_NAME).(ZONE_NAME)"


### PR DESCRIPTION
Update the canary terraform module to include the necessary settings for
the canary updater container. Includes some modifications to the
github-flux module regarding the values. Yaml as strings again.

Updated the cluster template to include the monitoring chart in new
clusters.

- [ ] Merge https://github.com/alphagov/gsp-canary-chart/pull/6
- [ ] Change paths in various scripts in this PR to point back to master (see inline comments)

Solo: @blairboy362 