### PR TITLE
Add alertmanager-secret-values reference to alertmanager releases

### DIFF
--- a/terraform/clusters/cluster.re-managed-observe-production.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/cluster.re-managed-observe-production.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-release" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-monitoring-release" {
@@ -72,6 +74,8 @@ module "gsp-monitoring-release" {
   chart_git  = "https://github.com/alphagov/gsp-monitoring.git"
   chart_ref  = "master"
   chart_path = "monitoring"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-sealed-secrets" {
@@ -81,6 +85,8 @@ module "gsp-sealed-secrets" {
   chart_git  = "https://github.com/alphagov/gsp-sealed-secrets.git"
   chart_ref  = "master"
   chart_path = "charts/sealed-secrets"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "observe-alertmanager" {
@@ -90,4 +96,6 @@ module "observe-alertmanager" {
   chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
   chart_ref  = "master"
   valueFileSecrets = ["alertmanager-secret-values"]
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }

--- a/terraform/clusters/cluster.re-managed-observe-production.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/cluster.re-managed-observe-production.aws.ext.govsvc.uk/cluster.tf
@@ -89,5 +89,5 @@ module "observe-alertmanager" {
   namespace  = "alertmanager"
   chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
   chart_ref  = "master"
-  chart_path = ""
+  valueFileSecrets = ["alertmanager-secret-values"]
 }

--- a/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
@@ -89,6 +89,6 @@ module "observe-alertmanager" {
   namespace  = "alertmanager"
   chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
   chart_ref  = "master"
-  chart_path = ""
+  valueFileSecrets = ["alertmanager-secret-values"]
 }
 

--- a/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/cluster.re-managed-observe-staging.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-release" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-monitoring-release" {
@@ -72,6 +74,8 @@ module "gsp-monitoring-release" {
   chart_git  = "https://github.com/alphagov/gsp-monitoring.git"
   chart_ref  = "master"
   chart_path = "monitoring"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-sealed-secrets" {
@@ -81,6 +85,8 @@ module "gsp-sealed-secrets" {
   chart_git  = "https://github.com/alphagov/gsp-sealed-secrets.git"
   chart_ref  = "master"
   chart_path = "charts/sealed-secrets"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "observe-alertmanager" {
@@ -90,5 +96,7 @@ module "observe-alertmanager" {
   chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
   chart_ref  = "master"
   valueFileSecrets = ["alertmanager-secret-values"]
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 

--- a/terraform/clusters/danielblair.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/danielblair.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-flux-helm" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-canary" {

--- a/terraform/clusters/davidpye.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidpye.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-flux-helm" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-monitoring-release" {
@@ -72,6 +74,8 @@ module "gsp-monitoring-release" {
   chart_git  = "https://github.com/alphagov/gsp-monitoring.git"
   chart_ref  = "master"
   chart_path = "monitoring"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-canary" {

--- a/terraform/clusters/dougneal.gds-re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/dougneal.gds-re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-release" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-canary" {

--- a/terraform/clusters/farms.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/farms.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -82,3 +82,12 @@ module "gsp-monitoring-release" {
   chart_ref  = "master"
   chart_path = "monitoring"
 }
+
+module "observe-alertmanager" {
+  source = "../../modules/github-flux"
+
+  namespace  = "alertmanager"
+  chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
+  chart_ref  = "use-gsp-monitoring-operator"
+  valueFileSecrets = ["alertmanager-secret-values"]
+}

--- a/terraform/clusters/farms.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/farms.re-run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -63,6 +63,8 @@ module "gsp-base-release" {
   chart_git  = "https://github.com/alphagov/gsp-base.git"
   chart_ref  = "master"
   chart_path = "charts/base"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-sealed-secrets" {
@@ -72,6 +74,8 @@ module "gsp-sealed-secrets" {
   chart_git  = "https://github.com/alphagov/gsp-sealed-secrets.git"
   chart_ref  = "master"
   chart_path = "charts/sealed-secrets"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "gsp-monitoring-release" {
@@ -81,6 +85,8 @@ module "gsp-monitoring-release" {
   chart_git  = "https://github.com/alphagov/gsp-monitoring.git"
   chart_ref  = "master"
   chart_path = "monitoring"
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }
 
 module "observe-alertmanager" {
@@ -90,4 +96,6 @@ module "observe-alertmanager" {
   chart_git  = "https://github.com/alphagov/gsp-observe-alertmanager-spike.git"
   chart_ref  = "use-gsp-monitoring-operator"
   valueFileSecrets = ["alertmanager-secret-values"]
+  cluster_name = "${module.cluster.cluster_name}"
+  cluster_domain = "${module.cluster.cluster_name}.${module.cluster.zone_name}"
 }

--- a/terraform/modules/canary/main.tf
+++ b/terraform/modules/canary/main.tf
@@ -18,6 +18,8 @@ module "gsp-canary-release" {
   chart_git  = "${aws_codecommit_repository.canary.clone_url_http}"
   chart_ref  = "master"
   chart_path = "charts/gsp-canary"
+  cluster_name = ""
+  cluster_domain = "${var.cluster_id}"
   values = <<EOF
     updater:
       helmChartRepoUrl: ${aws_codecommit_repository.canary.clone_url_http}

--- a/terraform/modules/github-flux/data/helm-release.yaml
+++ b/terraform/modules/github-flux/data/helm-release.yaml
@@ -9,5 +9,6 @@ spec:
     git: "${chart_git}"
     ref: "${chart_ref}"
     path: "${chart_path}"
+  valueFileSecrets: ${valueFileSecrets}
   values:
 ${values}

--- a/terraform/modules/github-flux/data/helm-release.yaml
+++ b/terraform/modules/github-flux/data/helm-release.yaml
@@ -11,4 +11,7 @@ spec:
     path: "${chart_path}"
   valueFileSecrets: ${valueFileSecrets}
   values:
+    cluster:
+      name: ${cluster_name}
+      domain: ${cluster_domain}
 ${values}

--- a/terraform/modules/github-flux/data/values-secret.yaml
+++ b/terraform/modules/github-flux/data/values-secret.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${name}
+  namespace: ${namespace}

--- a/terraform/modules/github-flux/main.tf
+++ b/terraform/modules/github-flux/main.tf
@@ -32,6 +32,8 @@ data "template_file" "helm-release" {
     chart_git  = "${var.chart_git}"
     chart_ref  = "${var.chart_ref}"
     chart_path = "${var.chart_path}"
+    cluster_name = "${var.cluster_name}"
+    cluster_domain = "${var.cluster_domain}"
     values     = "${var.values}"
     valueFileSecrets = "[${join(",",formatlist("{\"name\":\"%s\"}", var.valueFileSecrets))}]"
   }

--- a/terraform/modules/github-flux/main.tf
+++ b/terraform/modules/github-flux/main.tf
@@ -41,3 +41,19 @@ resource "local_file" "helm-release-yaml" {
   filename = "${var.addons_dir}/${var.namespace}-helm-release.yaml"
   content  = "${data.template_file.helm-release.rendered}"
 }
+
+data "template_file" "values" {
+  count = "${length(var.valueFileSecrets)}"
+  template = "${file("${path.module}/data/values-secret.yaml")}"
+
+  vars {
+    namespace = "${var.namespace}"
+    name = "${var.valueFileSecrets[count.index]}"
+  }
+}
+
+resource "local_file" "values" {
+  count = "${length(var.valueFileSecrets)}"
+  filename = "${var.addons_dir}/${var.namespace}-${var.valueFileSecrets[count.index]}-values.yaml"
+  content  = "${data.template_file.values.*.rendered[count.index]}"
+}

--- a/terraform/modules/github-flux/main.tf
+++ b/terraform/modules/github-flux/main.tf
@@ -33,6 +33,7 @@ data "template_file" "helm-release" {
     chart_ref  = "${var.chart_ref}"
     chart_path = "${var.chart_path}"
     values     = "${var.values}"
+    valueFileSecrets = "[${join(",",formatlist("{\"name\":\"%s\"}", var.valueFileSecrets))}]"
   }
 }
 

--- a/terraform/modules/github-flux/variables.tf
+++ b/terraform/modules/github-flux/variables.tf
@@ -37,3 +37,13 @@ variable "valueFileSecrets" {
     type = "list"
     default = []
 }
+
+variable "cluster_name" {
+    description = "name of this cluster/environment (accessible as .Values.cluster.name in charts)"
+    type = "string"
+}
+
+variable "cluster_domain" {
+    description = "domain mapped to this cluster/environment (accessible as .Values.cluster.name in charts)"
+    type = "string"
+}

--- a/terraform/modules/github-flux/variables.tf
+++ b/terraform/modules/github-flux/variables.tf
@@ -29,3 +29,9 @@ variable "values" {
     type = "string"
     default = "    foo: bar # unused/arbitary, but must be at least one value or this breaks"
 }
+
+variable "valueFileSecrets" {
+    description = "List of names of Secrets containing additional helm values"
+    type = "list"
+    default = []
+}

--- a/terraform/modules/github-flux/variables.tf
+++ b/terraform/modules/github-flux/variables.tf
@@ -11,11 +11,13 @@ variable "chart_git" {
 variable "chart_ref" {
     description = "git ref/branch to watch"
     type = "string"
+    default = "master"
 }
 
 variable "chart_path" {
     description = "path within the git repository to a helm chart to deploy"
     type = "string"
+    default = ""
 }
 
 variable "addons_dir" {


### PR DESCRIPTION
## What

Updates alertmanager releases in observe-* clusters to make use of a helm values defined in a Secret

## How to review

The "farms" cluster is configured to point to the use-gsp-monitoring-operator branch as per https://github.com/alphagov/gsp-observe-alertmanager-spike/pull/3 so you can uyse that to test