### PR TITLE
Fix Variable Name Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@
     This should generate new file at the location:
 
     ```
-    terraform/clusters/${CLUSTER}.${AWS_ACCOUNT_NAME}.aws.ext.govsvc.uk/cluster.tf
+    terraform/clusters/${CLUSTER_NAME}.${AWS_ACCOUNT_NAME}.aws.ext.govsvc.uk/cluster.tf
     ```
 
     This leaves you with a manual steps of:
 
     ```sh
-    export DOMAIN=${CLUSTER}.${AWS_ACCOUNT_NAME}.aws.ext.govsvc.uk
+    export DOMAIN=${CLUSTER_NAME}.${AWS_ACCOUNT_NAME}.aws.ext.govsvc.uk
     cd terraform/clusters/${DOMAIN}
 
     # initialise terraform


### PR DESCRIPTION
CLUSTER variable should actually be CLUSTER_NAME

Co-authored-by: David Pye <david.pye@digital.cabinet-office.gov.uk>
Co-authored-by: Paul Dougan <paul.dougan@digital.cabinet-office.gov.uk>