### PR TITLE
watch master not provision-verify branch

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -166,7 +166,7 @@ resources:
   type: git
   source:
     uri: https://github.com/alphagov/gsp-teams.git
-    branch: provision-verify
+    branch: master
     paths:
     - "terraform/accounts/((account-name))/*"
     - "terraform/accounts/((account-name))/clusters/**/*"


### PR DESCRIPTION
fix: left the pipeline pointing at the wrong branch by mistake