### PR TITLE
Add splunk to verify EIDAS staging cluster

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -202,6 +202,9 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/staging.tfstate
+    <<: *terraform_vars
+      splunk_hec_token: ((splunk_hec_token))
+      splunk_hec_url: ((splunk_hec_url))
 - name: staging-cluster-bootstrapper
   type: terraform
   source:

--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -47,6 +47,7 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 0
+      splunk = 0
     }
 }
 

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -6,6 +6,14 @@ variable "aws_account_role_arn" {
   type = "string"
 }
 
+variable "splunk_hec_url" {
+  type = "string"
+}
+
+variable "splunk_hec_token" {
+  type = "string"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
@@ -41,12 +49,15 @@ module "gsp-cluster" {
       "85.133.67.244/32",
       "18.130.144.30/32", # autom8 concourse
     ]
+    splunk_hec_url = "${var.splunk_hec_url}"
+    splunk_hec_token = "${var.splunk_hec_token}"
     addons = {
       ingress = 1
       canary = 0
       monitoring = 1
       secrets = 1
       ci = 0
+      splunk = 1
     }
 }
 

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -47,6 +47,7 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 1
+      splunk = 0
     }
 }
 

--- a/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -25,7 +25,15 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 1
+      splunk = 0
     }
+
+    dev_user_arns = [
+      "arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/david.pye@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/david.mcdonald@digital.cabinet-office.gov.uk",
+    ]
+    dev_namespaces = ["kube-system", "flux-system", "secrets-system"]
 }
 
 module "prototype-kit" {

--- a/terraform/clusters/davidpye.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidpye.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -23,6 +23,7 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 1
+      splunk = 0
     }
 }
 

--- a/terraform/clusters/pauld.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/pauld.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -23,6 +23,7 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 1
+      splunk = 0
     }
 }
 

--- a/terraform/clusters/samcrang.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/samcrang.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -25,6 +25,7 @@ module "gsp-cluster" {
       monitoring = 1
       secrets = 1
       ci = 1
+      splunk = 0
     }
 }
 


### PR DESCRIPTION
https://trello.com/c/qboQ4xcn/223-ship-logs-from-cloudwatch-into-splunk

- turns off splunk for dev stacks
- turns off splunk for prod EIDAS and tools EIDAS clusters as asked by cyber sec. The plan would be to turn these on for prod go live and turn staging off.

Requires https://github.com/alphagov/gsp-terraform-ignition/pull/26/files to be merged first