### PR TITLE
Use 0.13.0-beta.1 of terraform resource

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -154,7 +154,7 @@ resource_types:
   type: docker-image
   source:
     repository: govsvc/terraform-resource
-    tag: 0.12.0-beta.1
+    tag: 0.13.0-beta.1
 
 
 


### PR DESCRIPTION
This image includes the `zip` package needed for terraform

See https://github.com/alphagov/gsp-docker-images/pull/8/files for more details. Note that PR will need merging and the docker image released before this PR can be merged

