### PR TITLE
Add splunk terraform vars to addons tasks

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -34,6 +34,8 @@ apply_addons_task: &apply_addons_task
     TERRAFORM_BUCKET: cd-gsp-private-qndvvc
     TERRAFORM_REGION: eu-west-2
     TF_VAR_aws_account_role_arn: ((account-role-arn))
+    TF_VAR_splunk_hec_token: ((splunk_hec_token))
+    TF_VAR_splunk_hec_url: ((splunk_hec_url))
   run:
     path: /bin/bash
     args:

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -21,6 +21,8 @@ provider "aws" {
   }
 }
 
+provider "null" {}
+
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {


### PR DESCRIPTION
We had to add these to all tasks (tools and production too) rather
than just staging as there is currently no way to do this per
cluster. This shouldn't actually do anything to tools and production,
just fix staging so that it has the variables it needs.

Has already been deployed and fixed this bug.