### PR TITLE
Staging EIDAS cluster to watch staging of verify-eidas-deployment

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -69,7 +69,7 @@ module "test-proxy-node" {
   namespace      = "test-proxy-node"
   release_name   = "test" # Has to be changed later down the line.
   chart_git      = "https://github.com/alphagov/verify-eidas-deployment.git"
-  chart_ref      = "master"
+  chart_ref      = "staging"
   chart_path     = "."
   cluster_name   = "${module.gsp-cluster.cluster-name}"
   cluster_domain = "${module.gsp-cluster.cluster-domain-suffix}"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -137,3 +137,7 @@ output "admin-kubeconfig" {
 output "kube-ca-crt" {
     value = "${module.gsp-cluster.kube-ca-crt}"
 }
+
+output "github-deployment-public-key" {
+    value = "${module.gsp-cluster.github-deployment-public-key}"
+}


### PR DESCRIPTION
https://trello.com/c/nZqPwMsF/112-create-a-pipeline-for-promoting-deployment-charts-between-environments

As part of promotion, staging cluster should deploy from staging
branch of verify-edias-deployment.

We will want to do the same for production cluster to watch
production ranch of verify-eidas-deployment. We will do this when we
are ready to go live.

We output the github deployment public key from terraform which
is to be manually copied and added to the verify-eidas-deployment
with read and write access.