### PR TITLE
Add AWS HSM to EIDAS staging and production clusters

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -51,6 +51,12 @@ module "gsp-cluster" {
     }
 }
 
+module "hsm" {
+  source       = "../../../../modules/hsm"
+  cluster_name = "${module.gsp-cluster.cluster-name}"
+  subnet_ids   = "${module.gsp-cluster.private-subnet-ids}"
+}
+
 output "bootstrap-base-userdata-source" {
     value = "${module.gsp-cluster.bootstrap-base-userdata-source}"
 }

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -63,6 +63,12 @@ module "gsp-cluster" {
     }
 }
 
+module "hsm" {
+  source       = "../../modules/hsm"
+  cluster_name = "${module.gsp-cluster.cluster-name}"
+  subnet_ids   = "${module.gsp-cluster.private-subnet-ids}"
+}
+
 module "test-proxy-node" {
   source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/flux-release"
 

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -1,0 +1,26 @@
+variable "subnet_ids" {
+  type = "list"
+}
+
+variable "cluster_name" {
+  type = "string"
+}
+
+resource "aws_cloudhsm_v2_cluster" "cluster" {
+  hsm_type   = "hsm1.medium"
+  subnet_ids = ["${var.subnet_ids}"]
+
+  tags = {
+    Name = "${var.cluster_name}-hsm-cluster"
+  }
+}
+
+# We can only create one HSM in Terraform rather than the multiple we require for high availability as you must create
+# a single HSM, initialise and activate it (which is done manually) before you can create more as they are clones of the
+# first HSM. The other HSMs will need to be created after the Terraform apply
+# Manual steps to initalise and activate the HSM can be followed from
+# https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html onwards
+resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
+  subnet_id  = "${aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]}"
+  cluster_id = "${aws_cloudhsm_v2_cluster.cluster.cluster_id}"
+}


### PR DESCRIPTION
Relies on https://github.com/alphagov/gsp-terraform-ignition/pull/35

## Design decisions

- I only attempt to spin up a single HSM in the terraform code.
I could have set the count of the resource to be the number of
private subnets and the terraform would have likely failed the first
time, required the manual activation of the first HSM and then may
pass on a second run. However I discounted this option as I saw
strange behaviour in Terraform where it would create two HSMs but
would error on the third. I don't know if these two HSMs were
clones of each other or not. I was under the impression that you
should only be able to create a single HSM until you had activated
it so I wanted to avoid this confusing behaviour. Instead we
can either put in a PR later to bump the count of HSMs or scale
them manually using the UI.

- I chose to put the HSM creation code in this repo and not
in terraform-ignition. The HSM seemed very tied to EIDAS rather than
all clusters and that's why I lean towards keeping it in this
repository. On top of this, I looked into whether there were issues
with the HSM security group being created outside the gsp-cluster
and was able to mitigate any issues I came across. For example,
adding the HSM security group to our worker nodes can't be done
after the creation of the launch configuration for the worker nodes
as there is no Terraform resource for this. However, instead you
can add security group rules to the worker nodes security group
to allow them to talk to the HSM rather than needing to attach
the HSM security group to the instances themselves.