### PR TITLE
Revert to a state without KIAM

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -16,7 +16,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=5efcabb9546967a5ca3cdaa60187404855a5e84f"
     cluster_name = "prod"
     controller_count = 2
     controller_instance_type = "m5d.large"

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -24,7 +24,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=5efcabb9546967a5ca3cdaa60187404855a5e84f"
     cluster_name = "staging"
     controller_count = 2
     controller_instance_type = "m5d.large"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -16,7 +16,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=5efcabb9546967a5ca3cdaa60187404855a5e84f"
     cluster_name = "tools"
     controller_count = 1
     controller_instance_type = "m5d.large"


### PR DESCRIPTION
## What

Sadly, the KIAM changes have somewhat broken down the Verify cluster.
For instance, the tool box is completely not accessible.

This is most likely with a side change enforcing the Canary to be always
enabled.

The clusters need to be running for the ongoing pen-tests and are not
required to have a canary just yet.

This should be then taken onto it's own story to establish the best ways
to proceed.

## How to review

- See if the hash is one before KIAM changes
- We may be here for a while guessing...