### PR TITLE
Fix codecommit access permissions for verify terraform pipeline

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -49,6 +49,7 @@ module "gsp-cluster" {
       ci = 0
       splunk = 0
     }
+    codecommit_init_role_arn = "${var.aws_account_role_arn}"
 }
 
 module "hsm" {

--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -43,7 +43,6 @@ module "gsp-cluster" {
     ]
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 0

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -55,7 +55,6 @@ module "gsp-cluster" {
     splunk_hec_token = "${var.splunk_hec_token}"
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 0

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -61,6 +61,7 @@ module "gsp-cluster" {
       ci = 0
       splunk = 1
     }
+    codecommit_init_role_arn = "${var.aws_account_role_arn}"
 }
 
 module "hsm" {

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -45,7 +45,6 @@ module "gsp-cluster" {
     ]
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 1

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -51,6 +51,7 @@ module "gsp-cluster" {
       ci = 1
       splunk = 0
     }
+    codecommit_init_role_arn = "${var.aws_account_role_arn}"
 }
 
 module "eidas-ci-pipelines" {

--- a/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -21,7 +21,6 @@ module "gsp-cluster" {
 
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 1

--- a/terraform/clusters/davidpye.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidpye.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -19,7 +19,6 @@ module "gsp-cluster" {
 
     addons = {
       ingress = 1
-      canary = 1
       monitoring = 1
       secrets = 1
       ci = 1

--- a/terraform/clusters/pauld.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/pauld.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -19,7 +19,6 @@ module "gsp-cluster" {
 
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 1

--- a/terraform/clusters/samcrang.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/samcrang.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -21,7 +21,6 @@ module "gsp-cluster" {
 
     addons = {
       ingress = 1
-      canary = 0
       monitoring = 1
       secrets = 1
       ci = 1


### PR DESCRIPTION
In the context of concourse, or when deferring the assume-role to
terraform as opposed to doing it outside like through aws-vault, the init
codecommit script doesn't inherit the assumed role environment so it would
fail to connect to codecommit with a 403. Pass the role arn down to the
updated gsp-cluster module so it can explicitly assume the right role.

- [ ] Merge https://github.com/alphagov/gsp-terraform-ignition/pull/37 before this

Solo: @blairboy362 