### PR TITLE
Add splunk index var

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -53,6 +53,7 @@ module "gsp-cluster" {
     ]
     splunk_hec_url = "${var.splunk_hec_url}"
     splunk_hec_token = "${var.splunk_hec_token}"
+    splunk_index = "verify_eidas_notification_k8s"
     addons = {
       ingress = 1
       canary = 0


### PR DESCRIPTION
This value has been chosen by the cyber team and fits the
corresponding PR:
https://github.com/alphagov/gsp-terraform-ignition/pull/38/files

Note, the change of index requires a new hec token to be used which must be added to concourse before this can be deployed.