### PR TITLE
Bump terraform-resource

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -156,7 +156,7 @@ resource_types:
   type: docker-image
   source:
     repository: govsvc/terraform-resource
-    tag: 0.13.0-beta.1
+    tag: 0.13.0-beta.2
 
 
 


### PR DESCRIPTION
## What

The new version of the resource should include `jq` needed by our
scripts to assume aws role.

## How to review

- Code review
- (although image already pushed) Should be merged after alphagov/gsp-docker-images#9