### PR TITLE
Define empty archive provider

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -13,6 +13,8 @@ provider "aws" {
   }
 }
 
+provider "archive" {}
+
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -21,6 +21,8 @@ provider "aws" {
   }
 }
 
+provider "archive" {}
+
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -13,6 +13,8 @@ provider "aws" {
   }
 }
 
+provider "archive" {}
+
 data "aws_caller_identity" "current" {}
 
 module "gsp-cluster" {


### PR DESCRIPTION
## What

Due to some changes in the modules, we are no longer using the provider.
The existing terraform state however didn't have a chance to catch-up,
meaning it would fail to apply any changes.

Defining the empty provider and removing it after application has worked
in the past and we're following the known pattern.

## How to review

- Code review should be sufficient