### PR TITLE
whitelist the autom8 egress for verify api-server

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -40,6 +40,7 @@ module "gsp-cluster" {
       "213.86.153.237/32",
       "85.133.67.244/32",
       "18.130.144.30/32", # autom8 concourse
+      "3.8.110.67/32",    # autom8 concourse
     ]
     addons = {
       ingress = 1

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -48,6 +48,7 @@ module "gsp-cluster" {
       "213.86.153.237/32",
       "85.133.67.244/32",
       "18.130.144.30/32", # autom8 concourse
+      "3.8.110.67/32",    # autom8 concourse
       "193.36.15.0/24", # TMP: Nettitude Pen-testers.
       "193.36.8.0/24", # TMP: Nettitude Pen-testers.
     ]

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -40,6 +40,7 @@ module "gsp-cluster" {
       "213.86.153.237/32",
       "85.133.67.244/32",
       "18.130.144.30/32", # autom8 concourse
+      "3.8.110.67/32",    # autom8 concourse
       "193.36.15.0/24", # TMP: Nettitude Pen-testers.
       "193.36.8.0/24", # TMP: Nettitude Pen-testers.
     ]


### PR DESCRIPTION
## What

the deployer concourse has two egress ips, we previously only
whitelisted one of them... this adds the second ip to allow deployer to
communicate with the provisioned cluster

## How to review

* Code review
* watch the deployer pipelines after merge
* check that the addons jobs ran successfully