### PR TITLE
Add eIDAS team members to dev roles in verify clusters.

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -63,6 +63,15 @@ module "gsp-cluster" {
       splunk = 1
     }
     codecommit_init_role_arn = "${var.aws_account_role_arn}"
+    dev_user_arns = [
+      "arn:aws:iam::622626885786:user/karol.gancarz@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/james.howes@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/anshul.sirur@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/daniel.besbrode@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/christopher.wynne@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/tom.rosier@digital.cabinet-office.gov.uk",
+    ]
+    dev_namespaces = ["test-proxy-node", "default"]
 }
 
 module "hsm" {

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -52,6 +52,15 @@ module "gsp-cluster" {
       splunk = 0
     }
     codecommit_init_role_arn = "${var.aws_account_role_arn}"
+    dev_user_arns = [
+      "arn:aws:iam::622626885786:user/karol.gancarz@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/james.howes@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/anshul.sirur@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/daniel.besbrode@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/christopher.wynne@digital.cabinet-office.gov.uk",
+      "arn:aws:iam::622626885786:user/tom.rosier@digital.cabinet-office.gov.uk",
+    ]
+    dev_namespaces = ["ci-system", "default"]
 }
 
 module "eidas-ci-pipelines" {


### PR DESCRIPTION
This should give the dev team read-only access to the namespaces so they
can have a poke around the cluster and connect to the concourse dashboard.