### PR TITLE
Attach rules to existing security group

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -73,9 +73,10 @@ module "gsp-cluster" {
 }
 
 module "hsm" {
-  source       = "../../../../modules/hsm"
-  cluster_name = "${module.gsp-cluster.cluster-name}"
-  subnet_ids   = "${module.gsp-cluster.private-subnet-ids}"
+  source             = "../../../../modules/hsm"
+  cluster_name       = "${module.gsp-cluster.cluster-name}"
+  subnet_ids         = "${module.gsp-cluster.private-subnet-ids}"
+  security_group_ids = ["${module.gsp-cluster.worker-security-group-ids}"]
 }
 
 module "test-proxy-node" {

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -30,6 +30,24 @@ resource "aws_security_group_rule" "hsm" {
   source_security_group_id = "${var.security_groups[count.index]}"
 }
 
+resource "aws_security_group_rule" "hsm-self-ingress" {
+  security_group_id        = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+  type                     = "ingress"
+  from_port                = 2223
+  to_port                  = 2225
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+}
+
+resource "aws_security_group_rule" "hsm-self-egress" {
+  security_group_id        = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+  type                     = "egress"
+  from_port                = 2223
+  to_port                  = 2225
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+}
+
 # We can only create one HSM in Terraform rather than the multiple we require for high availability as you must create
 # a single HSM, initialise and activate it (which is done manually) before you can create more as they are clones of the
 # first HSM. The other HSMs will need to be created after the Terraform apply

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -6,6 +6,11 @@ variable "cluster_name" {
   type = "string"
 }
 
+variable "security_group_ids" {
+  description = "List of security groups that are allowed to interact with HSM cluster"
+  type        = "list"
+}
+
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = ["${var.subnet_ids}"]
@@ -13,6 +18,16 @@ resource "aws_cloudhsm_v2_cluster" "cluster" {
   tags = {
     Name = "${var.cluster_name}-hsm-cluster"
   }
+}
+
+resource "aws_security_group_rule" "hsm" {
+  count                    = "${length(var.security_groups)}"
+  security_group_id        = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+  type                     = "ingress"
+  from_port                = 2223
+  to_port                  = 2225
+  protocol                 = "tcp"
+  source_security_group_id = "${var.security_groups[count.index]}"
 }
 
 # We can only create one HSM in Terraform rather than the multiple we require for high availability as you must create


### PR DESCRIPTION
There is a default security group that is being created as part of the
HSM. Instead of creating a new one - which would likely tear down the
HSM cluster - we can create a new set of rules and attach them to that
magical existing group.

This is required for the workers to be able to interact with the HSM
Cluster.

## Before merge

There is no way of testing it really. You could spin up the cluster and HSM (along with initialising it), then re-run `terraform apply` from this branch to make sure HSM cluster is not being destroyed.