### PR TITLE
Terraform persistent components separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Cluster configuration for GDS teams using the GDS Supported Platform.
    * `Type` field needs to be set to `NS - Name Server`
    * `Value` field needs to contain the `NS` records obtained from the Service
      Team's AWS account
+1. Create persistent Terraform
+
+    To create your network and other persistent resources for the base of your cluster, copy an existing configuration to manage from under `terraform/accounts/run-sandbox/persistent`--you probably want to tweak `resources.tf` appropriately.
+
+    This leaves you with a manual steps of:
+
+    ```sh
+    export AWS_DEFAULT_REGION=eu-west-2
+
+    cd terraform/accounts/${AWS_ACCOUNT_NAME}/persistent/${DOMAIN}
+
+    aws-vault exec run-sandbox -- terraform init -upgrade=true
+
+    aws-vault exec run-sandbox -- terraform apply
+    ```
 1. Create cluster Terraform
 
     Copy an existing cluster configuration from under `terraform/clusters`--you probably want to tweak `cluster.tf` appropriately.

--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -191,8 +191,8 @@ resources:
       key: ((account-name))/clusters/tools.tfstate
     vars:
       <<: *terraform_vars
-      cluster_state_bucket_name: cd-gsp-private-qndvvc
-      cluster_state_bucket_key: ((account-name))/clusters/tools-persistent.tfstate
+      persistent_state_bucket_name: cd-gsp-private-qndvvc
+      persistent_state_bucket_key: ((account-name))/clusters/tools-persistent.tfstate
 - name: tools-cluster-bootstrapper
   type: terraform
   source:

--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -1,4 +1,3 @@
-
 groups:
 - name: provision
   jobs:
@@ -14,8 +13,6 @@ groups:
   - destroy-tools-cluster
   - destroy-staging-cluster
   - destroy-prod-cluster
-
-
 
 
 
@@ -84,7 +81,6 @@ apply_addons_task: &apply_addons_task
   - name: gsp-teams
 
 
-
 wait_and_drain_bootstrapper: &wait_and_drain_bootstrapper
   platform: linux
   image_resource: *task_image_resource
@@ -110,7 +106,6 @@ wait_and_drain_bootstrapper: &wait_and_drain_bootstrapper
       kubectl --kubeconfig kubeconfig drain --ignore-daemonsets --force --grace-period=60 -l 'node-role.kubernetes.io/bootstrapper'
   inputs:
   - name: cluster-outputs
-
 
 
 destroy_bootstrapper: &destroy_bootstrapper
@@ -149,7 +144,6 @@ terraform_source: &terraform_source
 
 
 
-
 resource_types:
 
 - name: terraform
@@ -171,6 +165,7 @@ resources:
     branch: master
     paths:
     - "terraform/accounts/((account-name))/*"
+    - "terraform/accounts/((account-name))/persistent/**/*"
     - "terraform/accounts/((account-name))/clusters/**/*"
     - "terraform/modules/hsm/*"
 - name: common-infra
@@ -180,6 +175,13 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/common.tfstate
+- name: tools-persistent
+  type: terraform
+  source:
+    <<: *terraform_source
+    backend_config:
+      <<: *terraform_backend_config
+      key: ((account-name))/clusters/tools-persistent.tfstate
 - name: tools-cluster
   type: terraform
   source:
@@ -187,6 +189,10 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/tools.tfstate
+    vars:
+      <<: *terraform_vars
+      cluster_state_bucket_name: cd-gsp-private-qndvvc
+      cluster_state_bucket_key: ((account-name))/clusters/tools-persistent.tfstate
 - name: tools-cluster-bootstrapper
   type: terraform
   source:
@@ -198,6 +204,13 @@ resources:
       <<: *terraform_vars
       cluster_state_bucket_name: cd-gsp-private-qndvvc
       cluster_state_bucket_key: ((account-name))/clusters/tools.tfstate
+- name: staging-persistent
+  type: terraform
+  source:
+    <<: *terraform_source
+    backend_config:
+      <<: *terraform_backend_config
+      key: ((account-name))/clusters/staging-persistent.tfstate
 - name: staging-cluster
   type: terraform
   source:
@@ -207,6 +220,8 @@ resources:
       key: ((account-name))/clusters/staging.tfstate
     vars:
       <<: *terraform_vars
+      persistent_state_bucket_name: cd-gsp-private-qndvvc
+      persistent_state_bucket_key: ((account-name))/clusters/staging-persistent.tfstate
       splunk_hec_token: ((splunk_hec_token))
       splunk_hec_url: ((splunk_hec_url))
 - name: staging-cluster-bootstrapper
@@ -220,6 +235,13 @@ resources:
       <<: *terraform_vars
       cluster_state_bucket_name: cd-gsp-private-qndvvc
       cluster_state_bucket_key: ((account-name))/clusters/staging.tfstate
+- name: prod-persistent
+  type: terraform
+  source:
+    <<: *terraform_source
+    backend_config:
+      <<: *terraform_backend_config
+      key: ((account-name))/clusters/prod-persistent.tfstate
 - name: prod-cluster
   type: terraform
   source:
@@ -227,6 +249,10 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/prod.tfstate
+    vars:
+      <<: *terraform_vars
+      persistent_state_bucket_name: cd-gsp-private-qndvvc
+      persistent_state_bucket_key: ((account-name))/clusters/prod-persistent.tfstate
 - name: prod-cluster-bootstrapper
   type: terraform
   source:
@@ -254,6 +280,18 @@ jobs:
     params:
       env_name: ((account-name))
       terraform_source: gsp-teams/terraform/accounts/((account-name))/
+  - put: tools-persistent
+    params:
+      env_name: ((account-name))
+      terraform_source: gsp-teams/terraform/accounts/((account-name))/persistent/tools/
+  - put: staging-persistent
+    params:
+      env_name: ((account-name))
+      terraform_source: gsp-teams/terraform/accounts/((account-name))/persistent/staging/
+  - put: prod-persistent
+    params:
+      env_name: ((account-name))
+      terraform_source: gsp-teams/terraform/accounts/((account-name))/persistent/prod/
   - put: tools-cluster
     params:
       env_name: ((account-name))

--- a/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/main.tf
+++ b/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "gds-re-run-sandbox-terraform-state"
+    region = "eu-west-2"
+    key    = "davidmcdonald.run-sandbox.aws.ext.govsvc.uk/persistent.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
+++ b/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
@@ -1,0 +1,30 @@
+output "cert_pem" {
+  description = "Sealed secrets certificate"
+  value       = "${module.gsp-persistent.cert_pem}"
+}
+
+output "private_key_pem" {
+  description = "Sealed secrets private key"
+  value       = "${module.gsp-persistent.private_key_pem}"
+}
+
+output "private_subnet_ids" {
+  value = ["${module.gsp-network.private_subnet_ids}"]
+}
+
+output "public_subnet_ids" {
+  value = ["${module.gsp-network.public_subnet_ids}"]
+}
+
+output "network_id" {
+  value = "${module.gsp-network.network_id}"
+}
+
+output "nat_gateway_public_ips" {
+  value = ["${module.gsp-network.nat_gateway_public_ips}"]
+}
+
+output "host_cidr" {
+  description = "CIDR IPv4 range to assign to EC2 nodes"
+  value       = "${module.gsp-network.host_cidr}"
+}

--- a/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
+++ b/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
@@ -1,11 +1,11 @@
-output "cert_pem" {
+output "sealed_secrets_cert_pem" {
   description = "Sealed secrets certificate"
-  value       = "${module.gsp-persistent.cert_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_cert_pem}"
 }
 
-output "private_key_pem" {
+output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
-  value       = "${module.gsp-persistent.private_key_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
 }
 
 output "private_subnet_ids" {
@@ -16,8 +16,8 @@ output "public_subnet_ids" {
   value = ["${module.gsp-network.public_subnet_ids}"]
 }
 
-output "network_id" {
-  value = "${module.gsp-network.network_id}"
+output "vpc_id" {
+  value = "${module.gsp-network.vpc_id}"
 }
 
 output "nat_gateway_public_ips" {

--- a/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/resources.tf
+++ b/terraform/accounts/run-sandbox/persistent/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/resources.tf
@@ -1,0 +1,16 @@
+module "gsp-network" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=terraform_for_persistent_components"
+  cluster_name = "davidmcdonald"
+}
+
+module "gsp-persistent" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=terraform_for_persistent_components"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  dns_zone     = "run-sandbox.aws.ext.govsandbox.uk"
+}
+
+module "hsm" {
+  source       = "../../../../modules/hsm"
+  cluster_name = "davidmcdonald"
+  subnet_ids   = "${module.gsp-network.private_subnet_ids}"
+}

--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -61,13 +61,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
-    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
-    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
-    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
-    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
-    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
-    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
-    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
+    sealed_secrets_cert_pem        = "${data.terraform_remote_state.sealed_secrets_persistent_state.cert_pem}"
+    sealed_secrets_private_key_pem = "${data.terraform_remote_state.sealed_secrets_persistent_state.private_key_pem}"
+    vpc_id                         = "${data.terraform_remote_state.persistent_state.vpc_id}"
+    private_subnet_ids             = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids              = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                      = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips         = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     addons = {
       ingress = 1
       monitoring = 1

--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -6,6 +6,14 @@ variable "aws_account_role_arn" {
   type = "string"
 }
 
+variable "persistent_state_bucket_name" {
+  type = "string"
+}
+
+variable "persistent_state_bucket_key" {
+  type = "string"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
@@ -14,6 +22,17 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
+
+# Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
+data "terraform_remote_state" "persistent_state" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.persistent_state_bucket_name}"
+    key    = "${var.persistent_state_bucket_key}"
+    region = "eu-west-2"
+  }
+}
 
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
@@ -42,6 +61,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
+    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
+    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
+    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
+    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     addons = {
       ingress = 1
       monitoring = 1

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -14,6 +14,14 @@ variable "splunk_hec_token" {
   type = "string"
 }
 
+variable "persistent_state_bucket_name" {
+  type = "string"
+}
+
+variable "persistent_state_bucket_key" {
+  type = "string"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
@@ -22,6 +30,17 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
+
+# Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
+data "terraform_remote_state" "persistent_state" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.persistent_state_bucket_name}"
+    key    = "${var.persistent_state_bucket_key}"
+    region = "eu-west-2"
+  }
+}
 
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
@@ -50,6 +69,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
+    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
+    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
+    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
+    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     splunk_hec_url = "${var.splunk_hec_url}"
     splunk_hec_token = "${var.splunk_hec_token}"
     splunk_index = "verify_eidas_notification_k8s"
@@ -71,18 +97,6 @@ module "gsp-cluster" {
       "arn:aws:iam::622626885786:user/tom.rosier@digital.cabinet-office.gov.uk",
     ]
     dev_namespaces = ["test-proxy-node", "default"]
-}
-
-module "hsm" {
-  source             = "../../../../modules/hsm"
-  cluster_name       = "${module.gsp-cluster.cluster-name}"
-  subnet_ids         = "${module.gsp-cluster.private-subnet-ids}"
-  subnet_count       = "${module.gsp-cluster.private-subnet-count}" // https://github.com/hashicorp/terraform/issues/12570
-
-  splunk = 1
-  splunk_hec_url   = "${var.splunk_hec_url}"
-  splunk_hec_token = "${var.splunk_hec_token}"
-  splunk_index     = "verify_notification_hsm"
 }
 
 module "test-proxy-node" {

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -69,13 +69,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
-    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
-    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
-    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
-    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
-    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
-    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
-    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
+    sealed_secrets_cert_pem        = "${data.terraform_remote_state.sealed_secrets_persistent_state.cert_pem}"
+    sealed_secrets_private_key_pem = "${data.terraform_remote_state.sealed_secrets_persistent_state.private_key_pem}"
+    vpc_id                         = "${data.terraform_remote_state.persistent_state.vpc_id}"
+    private_subnet_ids             = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids              = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                      = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips         = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     splunk_hec_url = "${var.splunk_hec_url}"
     splunk_hec_token = "${var.splunk_hec_token}"
     splunk_index = "verify_eidas_notification_k8s"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -61,13 +61,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
-    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
-    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
-    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
-    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
-    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
-    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
-    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
+    sealed_secrets_cert_pem        = "${data.terraform_remote_state.sealed_secrets_persistent_state.cert_pem}"
+    sealed_secrets_private_key_pem = "${data.terraform_remote_state.sealed_secrets_persistent_state.private_key_pem}"
+    vpc_id                         = "${data.terraform_remote_state.persistent_state.vpc_id}"
+    private_subnet_ids             = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids              = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                      = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips         = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     addons = {
       ingress = 1
       monitoring = 1

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -6,6 +6,14 @@ variable "aws_account_role_arn" {
   type = "string"
 }
 
+variable "persistent_state_bucket_name" {
+  type = "string"
+}
+
+variable "persistent_state_bucket_key" {
+  type = "string"
+}
+
 provider "aws" {
   region = "eu-west-2"
   assume_role {
@@ -14,6 +22,17 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "current" {}
+
+# Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
+data "terraform_remote_state" "persistent_state" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.persistent_state_bucket_name}"
+    key    = "${var.persistent_state_bucket_key}"
+    region = "eu-west-2"
+  }
+}
 
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
@@ -42,6 +61,13 @@ module "gsp-cluster" {
       "18.130.144.30/32", # autom8 concourse
       "3.8.110.67/32",    # autom8 concourse
     ]
+    cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
+    private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
+    network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
+    private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+    public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+    host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
+    nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
     addons = {
       ingress = 1
       monitoring = 1

--- a/terraform/accounts/verify/persistent/prod/main.tf
+++ b/terraform/accounts/verify/persistent/prod/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "aws_account_role_arn" {
+  description = "ARN of the role in which this is being run"
+  type        = "string"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "${var.aws_account_role_arn}"
+  }
+}

--- a/terraform/accounts/verify/persistent/prod/outputs.tf
+++ b/terraform/accounts/verify/persistent/prod/outputs.tf
@@ -1,0 +1,30 @@
+output "cert_pem" {
+  description = "Sealed secrets certificate"
+  value       = "${module.gsp-persistent.cert_pem}"
+}
+
+output "private_key_pem" {
+  description = "Sealed secrets private key"
+  value       = "${module.gsp-persistent.private_key_pem}"
+}
+
+output "private_subnet_ids" {
+  value = ["${module.gsp-network.private_subnet_ids}"]
+}
+
+output "public_subnet_ids" {
+  value = ["${module.gsp-network.public_subnet_ids}"]
+}
+
+output "network_id" {
+  value = "${module.gsp-network.network_id}"
+}
+
+output "nat_gateway_public_ips" {
+  value = ["${module.gsp-network.nat_gateway_public_ips}"]
+}
+
+output "host_cidr" {
+  description = "CIDR IPv4 range to assign to EC2 nodes"
+  value       = "${module.gsp-network.host_cidr}"
+}

--- a/terraform/accounts/verify/persistent/prod/outputs.tf
+++ b/terraform/accounts/verify/persistent/prod/outputs.tf
@@ -1,11 +1,11 @@
-output "cert_pem" {
+output "sealed_secrets_cert_pem" {
   description = "Sealed secrets certificate"
-  value       = "${module.gsp-persistent.cert_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_cert_pem}"
 }
 
-output "private_key_pem" {
+output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
-  value       = "${module.gsp-persistent.private_key_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
 }
 
 output "private_subnet_ids" {
@@ -16,8 +16,8 @@ output "public_subnet_ids" {
   value = ["${module.gsp-network.public_subnet_ids}"]
 }
 
-output "network_id" {
-  value = "${module.gsp-network.network_id}"
+output "vpc_id" {
+  value = "${module.gsp-network.vpc_id}"
 }
 
 output "nat_gateway_public_ips" {

--- a/terraform/accounts/verify/persistent/prod/resources.tf
+++ b/terraform/accounts/verify/persistent/prod/resources.tf
@@ -1,0 +1,16 @@
+module "gsp-network" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network"
+  cluster_name = "prod"
+}
+
+module "gsp-persistent" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  dns_zone     = "verify.govsvc.uk"
+}
+
+module "hsm" {
+  source       = "../../../../modules/hsm"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  subnet_ids   = "${module.gsp-network.private_subnet_ids}"
+}

--- a/terraform/accounts/verify/persistent/staging/main.tf
+++ b/terraform/accounts/verify/persistent/staging/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "aws_account_role_arn" {
+  description = "ARN of the role in which this is being run"
+  type        = "string"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "${var.aws_account_role_arn}"
+  }
+}

--- a/terraform/accounts/verify/persistent/staging/outputs.tf
+++ b/terraform/accounts/verify/persistent/staging/outputs.tf
@@ -1,0 +1,30 @@
+output "cert_pem" {
+  description = "Sealed secrets certificate"
+  value       = "${module.gsp-persistent.cert_pem}"
+}
+
+output "private_key_pem" {
+  description = "Sealed secrets private key"
+  value       = "${module.gsp-persistent.private_key_pem}"
+}
+
+output "private_subnet_ids" {
+  value = ["${module.gsp-network.private_subnet_ids}"]
+}
+
+output "public_subnet_ids" {
+  value = ["${module.gsp-network.public_subnet_ids}"]
+}
+
+output "network_id" {
+  value = "${module.gsp-network.network_id}"
+}
+
+output "nat_gateway_public_ips" {
+  value = ["${module.gsp-network.nat_gateway_public_ips}"]
+}
+
+output "host_cidr" {
+  description = "CIDR IPv4 range to assign to EC2 nodes"
+  value       = "${module.gsp-network.host_cidr}"
+}

--- a/terraform/accounts/verify/persistent/staging/outputs.tf
+++ b/terraform/accounts/verify/persistent/staging/outputs.tf
@@ -1,11 +1,11 @@
-output "cert_pem" {
+output "sealed_secrets_cert_pem" {
   description = "Sealed secrets certificate"
-  value       = "${module.gsp-persistent.cert_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_cert_pem}"
 }
 
-output "private_key_pem" {
+output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
-  value       = "${module.gsp-persistent.private_key_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
 }
 
 output "private_subnet_ids" {
@@ -16,8 +16,8 @@ output "public_subnet_ids" {
   value = ["${module.gsp-network.public_subnet_ids}"]
 }
 
-output "network_id" {
-  value = "${module.gsp-network.network_id}"
+output "vpc_id" {
+  value = "${module.gsp-network.vpc_id}"
 }
 
 output "nat_gateway_public_ips" {

--- a/terraform/accounts/verify/persistent/staging/resources.tf
+++ b/terraform/accounts/verify/persistent/staging/resources.tf
@@ -1,0 +1,16 @@
+module "gsp-network" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network"
+  cluster_name = "staging"
+}
+
+module "gsp-persistent" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  dns_zone     = "verify.govsvc.uk"
+}
+
+module "hsm" {
+  source       = "../../../../modules/hsm"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  subnet_ids   = "${module.gsp-network.private_subnet_ids}"
+}

--- a/terraform/accounts/verify/persistent/tools/main.tf
+++ b/terraform/accounts/verify/persistent/tools/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "aws_account_role_arn" {
+  description = "ARN of the role in which this is being run"
+  type        = "string"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "${var.aws_account_role_arn}"
+  }
+}

--- a/terraform/accounts/verify/persistent/tools/outputs.tf
+++ b/terraform/accounts/verify/persistent/tools/outputs.tf
@@ -1,0 +1,30 @@
+output "cert_pem" {
+  description = "Sealed secrets certificate"
+  value       = "${module.gsp-persistent.cert_pem}"
+}
+
+output "private_key_pem" {
+  description = "Sealed secrets private key"
+  value       = "${module.gsp-persistent.private_key_pem}"
+}
+
+output "private_subnet_ids" {
+  value = ["${module.gsp-network.private_subnet_ids}"]
+}
+
+output "public_subnet_ids" {
+  value = ["${module.gsp-network.public_subnet_ids}"]
+}
+
+output "network_id" {
+  value = "${module.gsp-network.network_id}"
+}
+
+output "nat_gateway_public_ips" {
+  value = ["${module.gsp-network.nat_gateway_public_ips}"]
+}
+
+output "host_cidr" {
+  description = "CIDR IPv4 range to assign to EC2 nodes"
+  value       = "${module.gsp-network.host_cidr}"
+}

--- a/terraform/accounts/verify/persistent/tools/outputs.tf
+++ b/terraform/accounts/verify/persistent/tools/outputs.tf
@@ -1,11 +1,11 @@
-output "cert_pem" {
+output "sealed_secrets_cert_pem" {
   description = "Sealed secrets certificate"
-  value       = "${module.gsp-persistent.cert_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_cert_pem}"
 }
 
-output "private_key_pem" {
+output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
-  value       = "${module.gsp-persistent.private_key_pem}"
+  value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
 }
 
 output "private_subnet_ids" {
@@ -16,8 +16,8 @@ output "public_subnet_ids" {
   value = ["${module.gsp-network.public_subnet_ids}"]
 }
 
-output "network_id" {
-  value = "${module.gsp-network.network_id}"
+output "vpc_id" {
+  value = "${module.gsp-network.vpc_id}"
 }
 
 output "nat_gateway_public_ips" {

--- a/terraform/accounts/verify/persistent/tools/resources.tf
+++ b/terraform/accounts/verify/persistent/tools/resources.tf
@@ -1,0 +1,10 @@
+module "gsp-network" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network"
+  cluster_name = "tools"
+}
+
+module "gsp-persistent" {
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent"
+  cluster_name = "${module.gsp-network.cluster-name}"
+  dns_zone     = "verify.govsvc.uk"
+}

--- a/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -8,31 +8,56 @@ terraform {
 
 data "aws_caller_identity" "current" {}
 
+# Terraform state that persists between respins of the cluster. This Terraform state contains HSM, sealed secrets, etc.
+data "terraform_remote_state" "persistent_state" {
+  backend = "s3"
+
+  config {
+    bucket = "gds-re-run-sandbox-terraform-state"
+    key    = "davidmcdonald.run-sandbox.aws.ext.govsvc.uk/persistent.tfstate"
+    region = "eu-west-2"
+  }
+}
+
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
-    cluster_name = "davidmcdonald"
-    dns_zone = "run-sandbox.aws.ext.govsandbox.uk"
-    user_data_bucket_name = "gds-re-run-sandbox-terraform-state"
-    user_data_bucket_region = "eu-west-2"
-    k8s_tag = "v1.12.2"
-    admin_role_arns = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
-    controller_instance_type = "m5d.large"
-    worker_instance_type = "m5d.large"
+  source                   = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=terraform_for_persistent_components"
+  cluster_name             = "davidmcdonald"
+  dns_zone                 = "run-sandbox.aws.ext.govsandbox.uk"
+  user_data_bucket_name    = "gds-re-run-sandbox-terraform-state"
+  user_data_bucket_region  = "eu-west-2"
+  k8s_tag                  = "v1.12.2"
+  admin_role_arns          = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
+  controller_instance_type = "m5d.large"
+  worker_instance_type     = "m5d.large"
+  cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
+  private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
+  network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
+  private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+  public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+  host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
+  nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
 
-    addons = {
-      ingress = 1
-      monitoring = 1
-      secrets = 1
-      ci = 1
-      splunk = 0
-    }
+  addons = {
+    ingress    = 1
+    monitoring = 1
+    secrets    = 1
+    ci         = 1
+    splunk     = 0
+  }
 
-    dev_user_arns = [
-      "arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk",
-      "arn:aws:iam::622626885786:user/david.pye@digital.cabinet-office.gov.uk",
-      "arn:aws:iam::622626885786:user/david.mcdonald@digital.cabinet-office.gov.uk",
-    ]
-    dev_namespaces = ["kube-system", "flux-system", "secrets-system"]
+  dev_user_arns = [
+    "arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk",
+    "arn:aws:iam::622626885786:user/david.pye@digital.cabinet-office.gov.uk",
+    "arn:aws:iam::622626885786:user/david.mcdonald@digital.cabinet-office.gov.uk",
+  ]
+
+  dev_namespaces = ["kube-system", "flux-system", "secrets-system"]
+}
+
+module "hsm" {
+  source       = "../../modules/hsm"
+  cluster_name = "davidmcdonald"
+  subnet_ids   = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
 }
 
 module "prototype-kit" {
@@ -45,6 +70,7 @@ module "prototype-kit" {
   cluster_name   = "${module.gsp-cluster.cluster-name}"
   cluster_domain = "${module.gsp-cluster.cluster-domain-suffix}"
   addons_dir     = "addons/${module.gsp-cluster.cluster-name}"
+
   values = <<EOF
     ingress:
       hosts:

--- a/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
+++ b/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/cluster.tf
@@ -20,22 +20,22 @@ data "terraform_remote_state" "persistent_state" {
 }
 
 module "gsp-cluster" {
-  source                   = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=terraform_for_persistent_components"
-  cluster_name             = "davidmcdonald"
-  dns_zone                 = "run-sandbox.aws.ext.govsandbox.uk"
-  user_data_bucket_name    = "gds-re-run-sandbox-terraform-state"
-  user_data_bucket_region  = "eu-west-2"
-  k8s_tag                  = "v1.12.2"
-  admin_role_arns          = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
-  controller_instance_type = "m5d.large"
-  worker_instance_type     = "m5d.large"
-  cert_pem                 = "${data.terraform_remote_state.persistent_state.cert_pem}"
-  private_key_pem          = "${data.terraform_remote_state.persistent_state.private_key_pem}"
-  network_id               = "${data.terraform_remote_state.persistent_state.network_id}"
-  private_subnet_ids       = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
-  public_subnet_ids        = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
-  host_cidr                = "${data.terraform_remote_state.persistent_state.host_cidr}"
-  nat_gateway_public_ips   = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
+  source                         = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=terraform_for_persistent_components"
+  cluster_name                   = "davidmcdonald"
+  dns_zone                       = "run-sandbox.aws.ext.govsandbox.uk"
+  user_data_bucket_name          = "gds-re-run-sandbox-terraform-state"
+  user_data_bucket_region        = "eu-west-2"
+  k8s_tag                        = "v1.12.2"
+  admin_role_arns                = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/admin"]
+  controller_instance_type       = "m5d.large"
+  worker_instance_type           = "m5d.large"
+  sealed_secrets_cert_pem        = "${data.terraform_remote_state.persistent_state.sealed_secrets_cert_pem}"
+  sealed_secrets_private_key_pem = "${data.terraform_remote_state.persistent_state.sealed_secrets_private_key_pem}"
+  vpc_id                         = "${data.terraform_remote_state.persistent_state.vpc_id}"
+  private_subnet_ids             = "${data.terraform_remote_state.persistent_state.private_subnet_ids}"
+  public_subnet_ids              = "${data.terraform_remote_state.persistent_state.public_subnet_ids}"
+  host_cidr                      = "${data.terraform_remote_state.persistent_state.host_cidr}"
+  nat_gateway_public_ips         = "${data.terraform_remote_state.persistent_state.nat_gateway_public_ips}"
 
   addons = {
     ingress    = 1

--- a/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
+++ b/terraform/clusters/davidmcdonald.run-sandbox.aws.ext.govsvc.uk/outputs.tf
@@ -1,60 +1,60 @@
 output "bootstrap-base-userdata-source" {
-    value = "${module.gsp-cluster.bootstrap-base-userdata-source}"
+  value = "${module.gsp-cluster.bootstrap-base-userdata-source}"
 }
 
 output "bootstrap-base-userdata-verification" {
-    value = "${module.gsp-cluster.bootstrap-base-userdata-verification}"
+  value = "${module.gsp-cluster.bootstrap-base-userdata-verification}"
 }
 
 output "user-data-bucket-name" {
-    value = "${module.gsp-cluster.user_data_bucket_name}"
+  value = "${module.gsp-cluster.user_data_bucket_name}"
 }
 
 output "user-data-bucket-region" {
-    value = "${module.gsp-cluster.user_data_bucket_region}"
+  value = "${module.gsp-cluster.user_data_bucket_region}"
 }
 
 output "cluster-name" {
-    value = "${module.gsp-cluster.cluster-name}"
+  value = "${module.gsp-cluster.cluster-name}"
 }
 
 output "controller-security-group-ids" {
-    value = ["${module.gsp-cluster.controller-security-group-ids}"]
+  value = ["${module.gsp-cluster.controller-security-group-ids}"]
 }
 
 output "bootstrap-subnet-id" {
-    value = "${module.gsp-cluster.bootstrap-subnet-id}"
+  value = "${module.gsp-cluster.bootstrap-subnet-id}"
 }
 
 output "controller-instance-profile-name" {
-    value = "${module.gsp-cluster.controller-instance-profile-name}"
+  value = "${module.gsp-cluster.controller-instance-profile-name}"
 }
 
 output "apiserver-lb-target-group-arn" {
-    value = "${module.gsp-cluster.apiserver-lb-target-group-arn}"
+  value = "${module.gsp-cluster.apiserver-lb-target-group-arn}"
 }
 
 output "dns-service-ip" {
-    value = "${module.gsp-cluster.dns-service-ip}"
+  value = "${module.gsp-cluster.dns-service-ip}"
 }
 
 output "cluster-domain-suffix" {
-    value = "${module.gsp-cluster.cluster-domain-suffix}"
+  value = "${module.gsp-cluster.cluster-domain-suffix}"
 }
 
 output "k8s-tag" {
-    value = "${module.gsp-cluster.k8s_tag}"
+  value = "${module.gsp-cluster.k8s_tag}"
 }
 
 output "kubelet-kubeconfig" {
-    value = "${module.gsp-cluster.kubelet-kubeconfig}"
-    sensitive = true
+  value     = "${module.gsp-cluster.kubelet-kubeconfig}"
+  sensitive = true
 }
 
 output "admin-kubeconfig" {
-    value = "${module.gsp-cluster.admin-kubeconfig}"
+  value = "${module.gsp-cluster.admin-kubeconfig}"
 }
 
 output "kube-ca-crt" {
-    value = "${module.gsp-cluster.kube-ca-crt}"
+  value = "${module.gsp-cluster.kube-ca-crt}"
 }


### PR DESCRIPTION
https://trello.com/c/wtEKyniL/283-separation-of-terraform-for-permanent-account-features-ie-hsms

Moves sealed secrets, HSM and VPC out of the cluster terraform project and into a persistent terraform project.

Note, in order for this to be deployed:
- We need to first initialise terraform remote states for the staging persistent project and then use `terraform mv` to move our HSM and VPC from the cluster project into the persistent project state
- https://github.com/alphagov/gsp-terraform-ignition/pull/49 needs to be merged

Paired: @poveyd and @idavidmcdonald 