### PR TITLE
Allow hsm access from within VPC subnets

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -76,7 +76,6 @@ module "hsm" {
   source             = "../../../../modules/hsm"
   cluster_name       = "${module.gsp-cluster.cluster-name}"
   subnet_ids         = "${module.gsp-cluster.private-subnet-ids}"
-  security_group_ids = ["${module.gsp-cluster.worker-security-group-ids}"]
 }
 
 module "test-proxy-node" {


### PR DESCRIPTION
# What

Revert recent change to allow ingress to hsm from workers with allowing ingress from anywhere inside the VPC private subnets.

Ideally we would only allow ingress from the "workers" security group to
lock it down a bit more, but this is not possible right now due to
ongoing work to split the hsm out into a seperate stage that is deployed
BEFORE the cluster exists.

# How to review

Code review