### PR TITLE
Scale out verify cluster control plane.

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -18,7 +18,7 @@ data "aws_caller_identity" "current" {}
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
     cluster_name = "prod"
-    controller_count = 2
+    controller_count = 3
     controller_instance_type = "m5d.large"
     worker_count = 3
     worker_instance_type = "m5d.large"

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -26,7 +26,7 @@ data "aws_caller_identity" "current" {}
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
     cluster_name = "staging"
-    controller_count = 2
+    controller_count = 3
     controller_instance_type = "m5d.large"
     worker_count = 2
     worker_instance_type = "m5d.large"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -18,7 +18,7 @@ data "aws_caller_identity" "current" {}
 module "gsp-cluster" {
     source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster"
     cluster_name = "tools"
-    controller_count = 1
+    controller_count = 3
     controller_instance_type = "m5d.large"
     worker_count = 1
     worker_instance_type = "m5d.large"


### PR DESCRIPTION
Following an outage caused by a routine reboot, we are scaling out the
control plane for the verify clusters to make them more resilient.