### PR TITLE
Send CloudHSM logs to Cyber's Splunk

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -53,6 +53,7 @@ module "gsp-cluster" {
     splunk_hec_url = "${var.splunk_hec_url}"
     splunk_hec_token = "${var.splunk_hec_token}"
     splunk_index = "verify_eidas_notification_k8s"
+
     addons = {
       ingress = 1
       monitoring = 1
@@ -76,6 +77,12 @@ module "hsm" {
   source             = "../../../../modules/hsm"
   cluster_name       = "${module.gsp-cluster.cluster-name}"
   subnet_ids         = "${module.gsp-cluster.private-subnet-ids}"
+  subnet_count       = "${module.gsp-cluster.private-subnet-count}" // https://github.com/hashicorp/terraform/issues/12570
+
+  splunk = 1
+  splunk_hec_url   = "${var.splunk_hec_url}"
+  splunk_hec_token = "${var.splunk_hec_token}"
+  splunk_index     = "verify_notification_hms"
 }
 
 module "test-proxy-node" {

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -66,7 +66,7 @@ module "lambda_splunk_forwarder" {
   source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/lambda_splunk_forwarder"
 
   enabled                   = "${var.splunk}"
-  name                      = "${var.cluster_name}_hsm"
+  name                      = "hsm"
   cloudwatch_log_group_arn  = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/cloudhsm/${aws_cloudhsm_v2_cluster.cluster.cluster_id}:*"
   cloudwatch_log_group_name = "/aws/cloudhsm/${aws_cloudhsm_v2_cluster.cluster.cluster_id}"
   cluster_name              = "${var.cluster_name}"

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -2,14 +2,37 @@ variable "subnet_ids" {
   type = "list"
 }
 
+variable "subnet_count" {
+  type = "string"
+}
+
 variable "cluster_name" {
   type = "string"
 }
 
 data "aws_subnet" "vpc" {
-  count = "${length(var.subnet_ids)}"
+  count = "${var.subnet_count}"
   id = "${var.subnet_ids[count.index]}"
 }
+
+variable "splunk" {
+  default = 0
+}
+
+variable "splunk_hec_url" {
+  type = "string"
+}
+
+variable "splunk_hec_token" {
+  type = "string"
+}
+
+variable "splunk_index" {
+  type = "string"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type   = "hsm1.medium"
@@ -37,4 +60,17 @@ resource "aws_security_group_rule" "hsm-worker-ingress" {
 resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
   subnet_id  = "${aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]}"
   cluster_id = "${aws_cloudhsm_v2_cluster.cluster.cluster_id}"
+}
+
+module "lambda_splunk_forwarder" {
+  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/lambda_splunk_forwarder"
+
+  enabled                   = "${var.splunk}"
+  name                      = "${var.cluster_name}_hsm"
+  cloudwatch_log_group_arn  = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/cloudhsm/${aws_cloudhsm_v2_cluster.cluster.cluster_id}:*"
+  cloudwatch_log_group_name = "/aws/cloudhsm/${aws_cloudhsm_v2_cluster.cluster.cluster_id}"
+  cluster_name              = "${var.cluster_name}"
+  splunk_hec_token          = "${var.splunk_hec_token}"
+  splunk_hec_url            = "${var.splunk_hec_url}"
+  splunk_index              = "${var.splunk_index}"
 }


### PR DESCRIPTION
Applying this may take at least two runs if applying from scratch. The
Lambda log forwarder requires that the CloudWatch log group for the HSM
exists. Given this is created by the CloudHSM it's likely Terraform will
experience a race condition as this log group won't have been created.

To avoid this we could create the log group with the HSM module, and
`terraform import` the currently deployed state. We're going to not
bother doing this for the time being because the HSM creation is so
infrequent.