### PR TITLE
fix typo in splunk-index

### DIFF
--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -82,7 +82,7 @@ module "hsm" {
   splunk = 1
   splunk_hec_url   = "${var.splunk_hec_url}"
   splunk_hec_token = "${var.splunk_hec_token}"
-  splunk_index     = "verify_notification_hms"
+  splunk_index     = "verify_notification_hsm"
 }
 
 module "test-proxy-node" {


### PR DESCRIPTION
## What

Typo in splunk index is suspected issued for hsm log shipping failure

## How to review

check you are happy with the transposed bytes