### PR TITLE
Add missing variables for terraforming hsm module in persistent state.

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -182,6 +182,10 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/tools-persistent.tfstate
+    vars:
+      <<: *terraform_vars
+      splunk_hec_token: ((splunk_hec_token))
+      splunk_hec_url: ((splunk_hec_url))
 - name: tools-cluster
   type: terraform
   source:
@@ -211,6 +215,10 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/staging-persistent.tfstate
+    vars:
+      <<: *terraform_vars
+      splunk_hec_token: ((splunk_hec_token))
+      splunk_hec_url: ((splunk_hec_url))
 - name: staging-cluster
   type: terraform
   source:
@@ -242,6 +250,10 @@ resources:
     backend_config:
       <<: *terraform_backend_config
       key: ((account-name))/clusters/prod-persistent.tfstate
+    vars:
+      <<: *terraform_vars
+      splunk_hec_token: ((splunk_hec_token))
+      splunk_hec_url: ((splunk_hec_url))
 - name: prod-cluster
   type: terraform
   source:

--- a/terraform/accounts/verify/persistent/staging/resources.tf
+++ b/terraform/accounts/verify/persistent/staging/resources.tf
@@ -10,7 +10,11 @@ module "gsp-persistent" {
 }
 
 module "hsm" {
-  source       = "../../../../modules/hsm"
-  cluster_name = "${module.gsp-network.cluster-name}"
-  subnet_ids   = "${module.gsp-network.private_subnet_ids}"
+  source           = "../../../../modules/hsm"
+  cluster_name     = "${module.gsp-network.cluster-name}"
+  subnet_ids       = "${module.gsp-network.private_subnet_ids}"
+  subnet_count     = "${module.gsp-network.private-subnet-count}" // https://github.com/hashicorp/terraform/issues/12570
+  splunk_hec_url   = "${var.splunk_hec_url}"
+  splunk_hec_token = "${var.splunk_hec_token}"
+  splunk_index     = "verify_notification_hsm"
 }

--- a/terraform/accounts/verify/persistent/staging/variables.tf
+++ b/terraform/accounts/verify/persistent/staging/variables.tf
@@ -1,0 +1,7 @@
+variable "splunk_hec_url" {
+  type = "string"
+}
+
+variable "splunk_hec_token" {
+  type = "string"
+}


### PR DESCRIPTION
Some variables were missed when migrating the hsm and other state out of
the cluster and into a dedicated persistent terraform statefile. This
updates the pipeline to pass the variables through to the hsm module.