### PR TITLE
Fix persistent remote state configuration.

### DIFF
--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -26,6 +26,7 @@ data "aws_caller_identity" "current" {}
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
 data "terraform_remote_state" "persistent_state" {
   backend = "s3"
+  workspace = "verify"
 
   config {
     bucket = "${var.persistent_state_bucket_name}"

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -34,6 +34,7 @@ data "aws_caller_identity" "current" {}
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
 data "terraform_remote_state" "persistent_state" {
   backend = "s3"
+  workspace = "verify"
 
   config {
     bucket = "${var.persistent_state_bucket_name}"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -26,6 +26,7 @@ data "aws_caller_identity" "current" {}
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
 data "terraform_remote_state" "persistent_state" {
   backend = "s3"
+  workspace = "verify"
 
   config {
     bucket = "${var.persistent_state_bucket_name}"


### PR DESCRIPTION
Terraform silently swallows the HTTP 404 that gets returned for an
incorrectly configured state bucket, allowing the apply to continue. Only
for it to fail later with missing required parameter values.

The pipeline sets config on the terraform tasks which adds a workspace to
the remote state. This results in the clusters not using the correct url
to load the remote state. Setting the workspace should fix it, as per
the bootstrapper terraform.