### PR TITLE
Pass on the public keys to the verify pipelines

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -53,7 +53,7 @@ apply_addons_task: &apply_addons_task
         -get=true \
         -input=false
       terraform workspace select "${ACCOUNT_NAME}"
-      terraform apply -auto-approve
+      terraform apply -var "public-gpg-keys=$(yq . ../../../users/*.yaml | jq -s '[.[].pub]' | base64)" -auto-approve
       echo "applying kubeyaml..."
       eval $(aws-assume-role $ACCOUNT_ROLE_ARN)
       until kubectl apply -R -f addons/; do
@@ -139,6 +139,7 @@ terraform_source: &terraform_source
     region: eu-west-2
   vars: &terraform_vars
     aws_account_role_arn: ((account-role-arn))
+    public-gpg-keys: "W10="
 
 
 

--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -139,7 +139,7 @@ terraform_source: &terraform_source
     region: eu-west-2
   vars: &terraform_vars
     aws_account_role_arn: ((account-role-arn))
-    public-gpg-keys: "W10="
+    public-gpg-keys: "W10=" # echo -n "[]" | base64
 
 
 

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -21,6 +21,11 @@ provider "aws" {
   }
 }
 
+variable "public-gpg-keys" {
+  type        = "string"
+  description = "Base64 JSON array of public gpg keys."
+}
+
 data "aws_caller_identity" "current" {}
 
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
@@ -99,6 +104,8 @@ module "eidas-ci-pipelines" {
   cluster_domain = "${module.gsp-cluster.cluster-domain-suffix}"
   addons_dir     = "addons/${module.gsp-cluster.cluster-name}"
   values = <<HEREDOC
+    github:
+      commit_verification_keys: ${base64decode(var.public-gpg-keys)}
     harbor:
       keys:
         ci: "${module.gsp-cluster.notary-ci-private-key}"


### PR DESCRIPTION
## What

We'd like to automatically read in our `users/` directory and obtain the
public key for people who are allowed to sign the commits when
contributing to app repositories.

It needs to be managed through terraform that will compose a new file in
`addons/` directory and then apply it to the cluster.

These keys then will be loaded by our tenant's concourse and embedded
into their pipelines where needed to avoid unsigned commits being rolled
into production environment or being built.

## How to review

- Sanity check
- Either run our pipelines locally... or trust it will work and/or fix later...