### PR TITLE
Add the default to the terraform

### DIFF
--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -24,6 +24,7 @@ provider "aws" {
 variable "public-gpg-keys" {
   type        = "string"
   description = "Base64 JSON array of public gpg keys."
+  default     = "W10="
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## What

The current state is only flawless if and when we're using a concourse
to deploy our clusters. Sadly, the dream of deploying our sandbox
cluster the same way is far away.

The easiest option that doesn't require people to be re-trained, is to
set a default for that variable.

The value, is simply an empty JSON array `[]` base64 encoded, to prevent
terraform's confusion with it's own implementation of lists which happens
to be exactly the same... _cry_

## How to review

- Sanity check