### PR TITLE
Commit verification for flux-releases

### DIFF
--- a/pipelines/tools-staging-prod-infra.yaml
+++ b/pipelines/tools-staging-prod-infra.yaml
@@ -33,6 +33,8 @@ apply_addons_task: &apply_addons_task
     TF_VAR_aws_account_role_arn: ((account-role-arn))
     TF_VAR_splunk_hec_token: ((splunk_hec_token))
     TF_VAR_splunk_hec_url: ((splunk_hec_url))
+    TF_VAR_promotion_signing_key: ((ci-system-gpg-private))
+    TF_VAR_promotion_verification_key: ((ci-system-gpg-public))
   run:
     path: /bin/bash
     args:
@@ -140,6 +142,8 @@ terraform_source: &terraform_source
   vars: &terraform_vars
     aws_account_role_arn: ((account-role-arn))
     public-gpg-keys: "W10=" # echo -n "[]" | base64
+    promotion_signing_key: ((ci-system-gpg-private))
+    promotion_verification_key: ((ci-system-gpg-public))
 
 
 

--- a/terraform/accounts/verify/bootstrapper/main.tf
+++ b/terraform/accounts/verify/bootstrapper/main.tf
@@ -33,7 +33,7 @@ resource "local_file" "admin-kubeconfig" {
 }
 
 module "k8s-bootstrap" {
-  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/k8s-bootstrap?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/k8s-bootstrap?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   bootstrap_base_userdata_source       = "${data.terraform_remote_state.cluster.bootstrap-base-userdata-source}"
   bootstrap_base_userdata_verification = "${data.terraform_remote_state.cluster.bootstrap-base-userdata-verification}"
   user_data_bucket_name                = "${data.terraform_remote_state.cluster.user-data-bucket-name}"

--- a/terraform/accounts/verify/clusters/prod/cluster.tf
+++ b/terraform/accounts/verify/clusters/prod/cluster.tf
@@ -36,7 +36,7 @@ data "terraform_remote_state" "persistent_state" {
 }
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
     cluster_name = "prod"
     controller_count = 3
     controller_instance_type = "m5d.large"

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -49,7 +49,7 @@ data "terraform_remote_state" "persistent_state" {
 }
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
     cluster_name = "staging"
     controller_count = 3
     controller_instance_type = "m5d.large"
@@ -106,7 +106,7 @@ module "gsp-cluster" {
 }
 
 module "test-proxy-node" {
-  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/flux-release?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/flux-release?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
 
   namespace      = "test-proxy-node"
   release_name   = "test" # Has to be changed later down the line.

--- a/terraform/accounts/verify/clusters/staging/cluster.tf
+++ b/terraform/accounts/verify/clusters/staging/cluster.tf
@@ -29,6 +29,11 @@ provider "aws" {
   }
 }
 
+variable "promotion_verification_key" {
+  type = "string"
+  description = "public gpg key used to verify git commits in flux-system"
+}
+
 data "aws_caller_identity" "current" {}
 
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
@@ -111,6 +116,7 @@ module "test-proxy-node" {
   cluster_name   = "${module.gsp-cluster.cluster-name}"
   cluster_domain = "${module.gsp-cluster.cluster-domain-suffix}"
   addons_dir     = "addons/${module.gsp-cluster.cluster-name}"
+  verification_keys = ["${var.promotion_verification_key}"]
 }
 
 output "bootstrap-base-userdata-source" {

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -51,7 +51,7 @@ data "terraform_remote_state" "persistent_state" {
 }
 
 module "gsp-cluster" {
-    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+    source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-cluster?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
     cluster_name = "tools"
     controller_count = 3
     controller_instance_type = "m5d.large"
@@ -104,7 +104,7 @@ module "gsp-cluster" {
 }
 
 module "eidas-ci-pipelines" {
-  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/flux-release?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/flux-release?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
 
   namespace      = "${module.gsp-cluster.ci-system-release-name}-main"
   chart_git      = "https://github.com/alphagov/verify-eidas-pipelines.git"

--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -26,6 +26,16 @@ variable "public-gpg-keys" {
   description = "Base64 JSON array of public gpg keys."
 }
 
+variable "promotion_signing_key" {
+  type = "string"
+  description = "private gpg key used to sign git commits in ci-system"
+}
+
+variable "promotion_verification_key" {
+  type = "string"
+  description = "public gpg key used to verify git commits in flux-system"
+}
+
 data "aws_caller_identity" "current" {}
 
 # Terraform state that persists between respins of the cluster. This Terraform state contains the VPC, HSM, persistent private keys etc
@@ -103,7 +113,10 @@ module "eidas-ci-pipelines" {
   cluster_name   = "${module.gsp-cluster.cluster-name}"
   cluster_domain = "${module.gsp-cluster.cluster-domain-suffix}"
   addons_dir     = "addons/${module.gsp-cluster.cluster-name}"
+  verification_keys = ["${var.promotion_verification_key}"]
+  
   values = <<HEREDOC
+    promotionSigningKey: ${format("%#v", var.promotion_signing_key)}
     github:
       commit_verification_keys: ${base64decode(var.public-gpg-keys)}
     harbor:

--- a/terraform/accounts/verify/persistent/prod/resources.tf
+++ b/terraform/accounts/verify/persistent/prod/resources.tf
@@ -1,10 +1,10 @@
 module "gsp-network" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "prod"
 }
 
 module "gsp-persistent" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "${module.gsp-network.cluster-name}"
   dns_zone     = "verify.govsvc.uk"
 }

--- a/terraform/accounts/verify/persistent/staging/resources.tf
+++ b/terraform/accounts/verify/persistent/staging/resources.tf
@@ -1,10 +1,10 @@
 module "gsp-network" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "staging"
 }
 
 module "gsp-persistent" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "${module.gsp-network.cluster-name}"
   dns_zone     = "verify.govsvc.uk"
 }

--- a/terraform/accounts/verify/persistent/tools/resources.tf
+++ b/terraform/accounts/verify/persistent/tools/resources.tf
@@ -1,10 +1,10 @@
 module "gsp-network" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-network?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "tools"
 }
 
 module "gsp-persistent" {
-  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source       = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/gsp-persistent?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
   cluster_name = "${module.gsp-network.cluster-name}"
   dns_zone     = "verify.govsvc.uk"
 }

--- a/terraform/modules/hsm/main.tf
+++ b/terraform/modules/hsm/main.tf
@@ -63,7 +63,7 @@ resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
 }
 
 module "lambda_splunk_forwarder" {
-  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/lambda_splunk_forwarder?ref=4a1d85a89c7b10f25bb1a583eab4d4845d01db92"
+  source = "git::https://github.com/alphagov/gsp-terraform-ignition//modules/lambda_splunk_forwarder?ref=fbc2c7896bd1f519eaea73ca1ac90be02a13e349"
 
   enabled                   = "${var.splunk}"
   name                      = "hsm"


### PR DESCRIPTION
### What

We [forked flux](https://github.com/alphagov/gsp-flux/tree/gds-master) to implement commit signing.... and [updated the flux-release modules](https://github.com/alphagov/gsp-terraform-ignition/pull/59) to accept commit verification.

This PR updates the pipelines to pass through the GPG private/public keys to the ci-system-main team and flux-releases that require them.

### Notes for review

* ~~There is a TMP commit to point to the commit in https://github.com/alphagov/gsp-terraform-ignition/pull/59 ... please ensure that PR is merged and the TMP commit references the correct SHA before merging~~