### PR TITLE
mark sealed secrets key as sensitive output

### DIFF
--- a/terraform/accounts/run-sandbox/persistent/samcrang.run-sandbox.aws.ext.govsvc.uk/outputs.tf
+++ b/terraform/accounts/run-sandbox/persistent/samcrang.run-sandbox.aws.ext.govsvc.uk/outputs.tf
@@ -6,6 +6,7 @@ output "sealed_secrets_cert_pem" {
 output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
   value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
+  sensitive   = true
 }
 
 output "private_subnet_ids" {

--- a/terraform/accounts/verify/persistent/prod/outputs.tf
+++ b/terraform/accounts/verify/persistent/prod/outputs.tf
@@ -6,6 +6,7 @@ output "sealed_secrets_cert_pem" {
 output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
   value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
+  sensitive   = true
 }
 
 output "private_subnet_ids" {

--- a/terraform/accounts/verify/persistent/staging/outputs.tf
+++ b/terraform/accounts/verify/persistent/staging/outputs.tf
@@ -6,6 +6,7 @@ output "sealed_secrets_cert_pem" {
 output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
   value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
+  sensitive   = true
 }
 
 output "private_subnet_ids" {

--- a/terraform/accounts/verify/persistent/tools/outputs.tf
+++ b/terraform/accounts/verify/persistent/tools/outputs.tf
@@ -6,6 +6,7 @@ output "sealed_secrets_cert_pem" {
 output "sealed_secrets_private_key_pem" {
   description = "Sealed secrets private key"
   value       = "${module.gsp-persistent.sealed_secrets_private_key_pem}"
+  sensitive   = true
 }
 
 output "private_subnet_ids" {


### PR DESCRIPTION
prevent terraform plan/apply from exposing the sealed secrets private
key during pipeline runs