### PR TITLE
Remove the deprecated output

### DIFF
--- a/terraform/accounts/verify/clusters/tools/cluster.tf
+++ b/terraform/accounts/verify/clusters/tools/cluster.tf
@@ -192,7 +192,3 @@ output "admin-kubeconfig" {
 output "kube-ca-crt" {
     value = "${module.gsp-cluster.kube-ca-crt}"
 }
-
-output "github-deployment-public-key" {
-    value = "${module.gsp-cluster.github-deployment-public-key}"
-}


### PR DESCRIPTION
We've moved this piece out of gsp-cluster module into flux-release. It
being here will cause the terraform to fail and stop the pipeline.