### PR TITLE
Use --yaml-var not --var when set-pipeline

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -11,6 +11,6 @@ fly -t gsp set-pipeline -p $ACCOUNT_NAME \
 	--config tools-staging-prod-infra.yaml \
 	--var account-name=$ACCOUNT_NAME \
 	--var account-role-arn=$DEPLOYER_ROLE_ARN \
-	--var public-gpg-keys=$(yq . ../users/*.yaml | jq -s '[.[] | select(.teams[] | IN("re-gsp")) | .pub]') \
+	--yaml-var public-gpg-keys="$(yq . ../users/*.yaml | jq -s '[.[] | select(.teams[] | IN("re-gsp")) | .pub]')" \
 	--check-creds
 ```


### PR DESCRIPTION
--var causes a big stringified blob when applying pipeline, it should be
--yaml-var