### PR TITLE
silence set-pipeline dirty checking

### DIFF
--- a/hack/set-pipeline.sh
+++ b/hack/set-pipeline.sh
@@ -6,11 +6,11 @@ PLATFORM_SRC="../gsp-terraform-ignition"
 
 : "${CLUSTER_NAME:?}"
 
-function git-status-not-say {
+function git-status-say {
   ( \
     cd "${PLATFORM_SRC}" \
-    && git fetch --all \
-    && git status --ignore-submodules | grep -i -v "${1}" \
+    && git fetch --all >/dev/null \
+    && git status --ignore-submodules | grep -i "${1}" >/dev/null \
   )
 }
 
@@ -18,11 +18,11 @@ if [[ "$(cd ${PLATFORM_SRC} && git rev-parse --abbrev-ref HEAD)" != "master" ]];
   echo "aborting: working copy of ${PLATFORM_SRC} is not on master"
   exit 1
 fi
-if git-status-not-say "working tree clean"; then
+if ! git-status-say "working tree clean"; then
   echo "aborting: working copy of ${PLATFORM_SRC} is not clean"
   exit 1
 fi
-if git-status-not-say "your branch is up to date"; then
+if ! git-status-say "your branch is up to date"; then
   echo "aborting: working copy of ${PLATFORM_SRC} is not up to date with the remote repository"
   exit 1
 fi


### PR DESCRIPTION
set-pipeline script was noisy and gave false positive when clean... silences output to dev/null and inverts the check