### PR TITLE
Add portfolio cluster configuration

### DIFF
--- a/clusters/portfolio.yaml
+++ b/clusters/portfolio.yaml
@@ -1,0 +1,23 @@
+account-id: "622626885786"
+account-name: "portfolio"
+account-role-arn: "arn:aws:iam::622626885786:role/deployer"
+cluster-name: "portfolio"
+cluster-number: "128"
+splunk-enabled: "0"
+splunk-hec-token: "NOTATOKEN"
+splunk-hec-url: "NOTAURL"
+github-client-secret: "NOTASECRET"
+github-client-id: "NOTID"
+eks-version: "1.12"
+platform-repository: "https://github.com/alphagov/gsp-terraform-ignition.git"
+platform-version: "2576e704172f0afb63a1ba5c64d5c27142f460f7"
+config-repository: "https://github.com/alphagov/gsp-teams.git"
+config-version: "master"
+config-path: "."
+trusted-developer-keys: []
+disable-destroy: true
+worker-instance-type: m5d.large
+worker-count: 3
+ci-worker-instance-type: t3.medium
+ci-worker-count: 3
+

--- a/users/anshul.sirur.yaml
+++ b/users/anshul.sirur.yaml
@@ -4,6 +4,7 @@ email: anshul.sirur@digital.cabinet-office.gov.uk
 ARN: arn:aws:iam::622626885786:user/anshul.sirur@digital.cabinet-office.gov.uk
 roles:
 - sandbox-sre
+- portfolio-sre
 hardware:
   id: 9607847
   type: yubikey

--- a/users/chris.farmiloe.yaml
+++ b/users/chris.farmiloe.yaml
@@ -6,6 +6,7 @@ roles:
 - farms-admin
 - verify-sre
 - sandbox-sre
+- portfolio-sre
 hardware:
   id: 9599175
   type: yubikey

--- a/users/daniel.blair.yaml
+++ b/users/daniel.blair.yaml
@@ -5,7 +5,7 @@ ARN: arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk
 roles:
 - verify-admin
 - sandbox-sre
-- portfolio-sre
+- portfolio-admin
 hardware:
   id: 9607848
   type: yubikey

--- a/users/daniel.blair.yaml
+++ b/users/daniel.blair.yaml
@@ -5,6 +5,7 @@ ARN: arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk
 roles:
 - verify-admin
 - sandbox-sre
+- portfolio-sre
 hardware:
   id: 9607848
   type: yubikey

--- a/users/rafal.proszowski.yaml
+++ b/users/rafal.proszowski.yaml
@@ -5,6 +5,7 @@ ARN: arn:aws:iam::622626885786:user/rafal.proszowski@digital.cabinet-office.gov.
 roles:
 - verify-sre
 - sandbox-sre
+- portfolio-sre
 hardware:
   type: yubikey
   personal: true

--- a/users/rafal.proszowski.yaml
+++ b/users/rafal.proszowski.yaml
@@ -5,7 +5,7 @@ ARN: arn:aws:iam::622626885786:user/rafal.proszowski@digital.cabinet-office.gov.
 roles:
 - verify-sre
 - sandbox-sre
-- portfolio-sre
+- portfolio-admin
 hardware:
   type: yubikey
   personal: true

--- a/users/sam.crang.yaml
+++ b/users/sam.crang.yaml
@@ -5,6 +5,7 @@ ARN: arn:aws:iam::622626885786:user/sam.crang@digital.cabinet-office.gov.uk
 roles:
 - verify-sre
 - sandbox-sre
+- portfolio-sre
 hardware:
   type: yubikey
   personal: true


### PR DESCRIPTION
## What

The team responsible for Portfolio, may also be onboarding teams onto
GSP. Adding the configuration pre-emptively to initiate this process.

There are no splunk configuration details at current time.

## How to review

- Sanity check

... Do not deploy/~push pipeline~ ... 🤔 