### PR TITLE
Make Daniel an admin in Verify to facilitate HSM initialisation.

### DIFF
--- a/users/daniel.blair.yaml
+++ b/users/daniel.blair.yaml
@@ -3,7 +3,7 @@ name: daniel.blair
 email: daniel.blair@digital.cabinet-office.gov.uk
 ARN: arn:aws:iam::622626885786:user/daniel.blair@digital.cabinet-office.gov.uk
 roles:
-- verify-sre
+- verify-admin
 - sandbox-sre
 hardware:
   id: 9607848


### PR DESCRIPTION
This will be rolled back once the HSM has been initialised.