### PR TITLE
add instance types to cluster configs

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -16,3 +16,7 @@ config-version: "master"
 config-path: "."
 trusted-developer-keys: []
 disable-destroy: false
+worker_instance_type: m5d.large
+worker_count: 3
+ci_worker_instance_type: t3.micro
+ci_worker_count: 3

--- a/clusters/verify.yaml
+++ b/clusters/verify.yaml
@@ -16,3 +16,7 @@ config-version: "master"
 config-path: "."
 trusted-developer-keys: []
 disable-destroy: true
+worker_instance_type: m5d.large
+worker_count: 3
+ci_worker_instance_type: t3.medium
+ci_worker_count: 3


### PR DESCRIPTION
the pipeline is now parameterised for configuring instance types, this
sets the types for sandbox and verify clusters

sandbox is using smaller ci-nodes as we do not currently expect to need
them much.