### PR TITLE
t3.micro is too small for ci worker

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -18,5 +18,5 @@ trusted-developer-keys: []
 disable-destroy: false
 worker-instance-type: m5d.large
 worker-count: 3
-ci-worker-instance-type: t3.micro
+ci-worker-instance-type: t3.small
 ci-worker-count: 3


### PR DESCRIPTION
t3.micro is only capable of running 4x pods due to the ENI limit.

4 pods will be running on each node as a minimum as there are daemonsets
for things like VPC CNI, istio, log shipping, ssm so there is no room
left for anything else.

t3.small is capable of running 12 pods (3x ENI with 4x IPs each) so is a
more reasonable choice.