### PR TITLE
BAU: Re-run failed tests

### DIFF
--- a/namespaces/verify-proxy-node-staging-test/build-pipeline.yaml
+++ b/namespaces/verify-proxy-node-staging-test/build-pipeline.yaml
@@ -87,7 +87,7 @@ spec:
         branch: master
 
     - name: verify-service-provider-config-repo
-      icon: gate
+      icon: settings
       type: github
       source:
         <<: *github_source

--- a/namespaces/verify-proxy-node-staging-test/deploy-pipeline.yaml
+++ b/namespaces/verify-proxy-node-staging-test/deploy-pipeline.yaml
@@ -306,6 +306,7 @@ spec:
             run: *await_changes
         - task: run-acceptance-tests
           image: acceptance-tests-image
+          attempts: 2
           timeout: 15m
           config:
             <<: *run-acceptance-tests-config


### PR DESCRIPTION
The tests seem to fail quite often due to seemingly random timeouts. This is an attempt to improve the reliability of our builds.

As suggested in https://github.com/alphagov/verify-eidas-pipelines/pull/42#issuecomment-492150739

Also change verify-service-provider-config-repo icon to settings