### PR TITLE
Deploy proxy-node to integration at least once a day

### DIFF
--- a/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
+++ b/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
@@ -41,6 +41,14 @@ spec:
       source:
         <<: *github_source
 
+    - name: daily
+      type: time
+      icon: update
+      source:
+        interval: 12h
+        start: 8:00 AM
+        stop: 8:00 PM
+
     jobs:
 
     - name: deploy-nl-integration
@@ -48,6 +56,9 @@ spec:
       plan:
 
       - get: release
+        trigger: true
+
+      - get: daily
         trigger: true
 
       - task: render-manifests

--- a/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
+++ b/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
@@ -136,4 +136,5 @@ spec:
                 --allow-ns "${RELEASE_NAMESPACE}" \
                 --app "${APP_NAME}" \
                 --diff-changes \
+                --labels "app=${APP_NAME},deployed-at=$(date +%s)" \
                 -f ./manifests/


### PR DESCRIPTION
## What

we'd like to ensure that the application gets deployed and rolled at least once a
day from the latest release so we can reason about the max lifetime of
the application pods.

* we add a unique "deployed-at" label so that there is always something unique to update on pods
* we add a timer to the deploy that triggers once a day between 8AM and 8PM (so that on the off-chance that the timer initiated deploy causes an issue, it will at least occur during waking hours)

... we intend to copy this pattern for prod deployments