### PR TITLE
Allow sandbox cluster to have less restrictive deployments

### DIFF
--- a/clusters/portfolio.yaml
+++ b/clusters/portfolio.yaml
@@ -26,4 +26,4 @@ worker-instance-type: m5d.large
 worker-count: 3
 ci-worker-instance-type: t3.medium
 ci-worker-count: 3
-
+git-resource-type: github

--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -26,3 +26,4 @@ worker-instance-type: m5d.large
 worker-count: 3
 ci-worker-instance-type: t3.small
 ci-worker-count: 3
+git-resource-type: git

--- a/clusters/verify.yaml
+++ b/clusters/verify.yaml
@@ -18,3 +18,4 @@ worker-count: 3
 ci-worker-instance-type: t3.large
 ci-worker-count: 3
 github-client-id: "1dbe43926d46b9ded8ad"
+git-resource-type: github


### PR DESCRIPTION
The `github` resource requires a PR with a minimum number of approvals.
This makes changes to the sandbox cluster (and possibly other places
where we need to iterate quickly) awkward.

This change replaces the `github` resource with the `git` resource in
the sandbox cluster.