### PR TITLE
Workaround for broken deployment.

### DIFF
--- a/namespaces/sandbox-proxy-node-integration/deploy-pipeline.yaml
+++ b/namespaces/sandbox-proxy-node-integration/deploy-pipeline.yaml
@@ -136,5 +136,5 @@ spec:
                 --allow-ns "${RELEASE_NAMESPACE}" \
                 --app "${APP_NAME}" \
                 --diff-changes \
-                --labels "app=${APP_NAME},deployed-at=$(date +%s)" \
+                --labels "app=${APP_NAME}" \
                 -f ./manifests/


### PR DESCRIPTION
A given label is immutable once a pod has been scheduled so a
time-sensitive value isn't appropriate.