### PR TITLE
Revert "Remove approval keys in an attempt to workaround approval requirements."

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -39,4 +39,3 @@ worker-count: 3
 ci-worker-instance-type: t3.small
 ci-worker-count: 3
 git-resource-type: git
-trusted-developer-keys: []


### PR DESCRIPTION
It didn't do anything..
Reverts alphagov/gsp-teams#186
