### PR TITLE
Workaround for broken NL deployment

### DIFF
--- a/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
+++ b/namespaces/verify-proxy-node-integration/deploy-pipeline.yaml
@@ -136,5 +136,5 @@ spec:
                 --allow-ns "${RELEASE_NAMESPACE}" \
                 --app "${APP_NAME}" \
                 --diff-changes \
-                --labels "app=${APP_NAME},deployed-at=$(date +%s)" \
+                --labels "app=${APP_NAME}" \
                 -f ./manifests/


### PR DESCRIPTION
A given label is immutable once a pod has been scheduled so a time-sensitive value isn't appropriate.
The same workaround [has been applied to the sandbox namespace](https://github.com/alphagov/gsp-teams/pull/185) but the old namespace is still being used.

