### PR TITLE
Restore test before release to build pipeline

### DIFF
--- a/namespaces/verify-proxy-node-build/release-pipeline.yaml
+++ b/namespaces/verify-proxy-node-build/release-pipeline.yaml
@@ -469,6 +469,7 @@ spec:
       plan:
 
       - get: chart
+        passed: ["test"]
         trigger: true
 
       - put: release


### PR DESCRIPTION
We deleted tests before release in <https://github.com/alphagov/gsp-teams/pull/192>.
This restores `test` to its correct position in pipeline