### PR TITLE
Use CloudHSM image from the correct registry

### DIFF
--- a/namespaces/verify-metadata-controller/release-pipeline.yaml
+++ b/namespaces/verify-metadata-controller/release-pipeline.yaml
@@ -77,6 +77,12 @@ spec:
         <<: *harbor_source
         repository: registry.((cluster.domain))/eidas/metadata-controller
 
+    - name: cloudhsm-image
+      type: harbor
+      icon: tag
+      source:
+        <<: *harbor_source
+        repository: registry.((cluster.domain))/eidas/cloudhsm
 
     jobs:
 
@@ -105,6 +111,9 @@ spec:
         - get: image
           passed: ["build"]
           trigger: true
+        - get: cloudhsm
+          passed: ["build"]
+          trigger: true
 
       - task: generate-chart-values
         config:
@@ -113,6 +122,7 @@ spec:
           inputs:
           - name: src
           - name: image
+          - name: clouhsm-image
           outputs:
           - name: chart-values
           run:
@@ -128,6 +138,10 @@ spec:
                   image:
                     repository: $(cat image/repository)@$(cat image/digest | cut -d ':' -f 1)
                     tag: $(cat image/digest | cut -d ':' -f 2)
+                hsm:
+                  image:
+                    repository: $(cat cloudhsm-image/repository)@$(cat cloudhsm-image/digest | cut -d ':' -f 1)
+                    tag: $(cat cloudhsm-image/digest | cut -d ':' -f 2)
                 EOF
                 echo "merging with chart values..."
                 spruce merge ./src/chart/values.yaml ./overrides.yaml | tee -a chart-values/values.yaml


### PR DESCRIPTION
cloudhsm is a container run by the vmc pod. We need to make sure we pull
it from a "proper" registry and not the default one that no longer
exists.