### PR TITLE
Adding an example namespace to portfolio

### DIFF
--- a/clusters/portfolio.yaml
+++ b/clusters/portfolio.yaml
@@ -39,4 +39,5 @@ worker-count: 3
 ci-worker-instance-type: t3.medium
 ci-worker-count: 3
 github-approval-count: 1
-namespaces: []
+namespaces:
+- name: portfolio-example


### PR DESCRIPTION
We need an example namespace to allow generate_namespace_values to pass within the deployment.

Solo: @smford