### PR TITLE
Increase the size of Sandbox CI workers from `t3.small` to `t3.large`

### DIFF
--- a/clusters/sandbox.yaml
+++ b/clusters/sandbox.yaml
@@ -31,7 +31,7 @@ users-path: "users"
 disable-destroy: false
 worker-instance-type: m5d.large
 worker-count: 6
-ci-worker-instance-type: t3.small
+ci-worker-instance-type: t3.large
 ci-worker-count: 3
 github-approval-count: 0
 config-approval-count: 0


### PR DESCRIPTION
As per the documentation - https://aws.amazon.com/ec2/pricing/on-demand/ - the small instances only have 2 GB of RAM. This doesn't seem like enough to run our integration tests and this may be causing the workers to disappear whilst running jobs. The large instances have 8 GB of RAM.
