### PR TITLE
Release metadata controller and connector node metadata from sandbox branch

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -12,14 +12,14 @@ namespaces:
 - name: sandbox-connector-node-metadata
   owner: alphagov
   repository: verify-metadata
-  branch: master
+  branch: sandbox
   path: ci/sandbox
   requiredApprovalCount: 0
 - name: sandbox-main
 - name: sandbox-metadata-controller
   owner: alphagov
   repository: verify-metadata-controller
-  branch: master
+  branch: sandbox
   path: ci
   requiredApprovalCount: 0
   scope: cluster


### PR DESCRIPTION
Release metadata from a non-master branch so devs can quickly test new changes before raising PRs to master
