### PR TITLE
Add Sandbox Stub Connector metadata endpoints to the HTTP egress safelist

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -7,6 +7,10 @@ global:
 httpsEgressSafelist:
 - name: sqs-eu-west-2
   fqdn: sqs.eu-west-2.amazonaws.com
+- name: stub-connector
+  fqdn: test-connector.london.sandbox.govsvc.uk
+- name: test-intgegration
+  fqdn: test-integration-connector.london.sandbox.govsvc.uk
 
 namespaces:
 - name: sandbox-connector-node-metadata


### PR DESCRIPTION
This is need so the ESP can access the connector metadata.