### PR TITLE
Add Hub integration metadata endpoint to the HTTP egress safelist.

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -11,6 +11,8 @@ httpsEgressSafelist:
   fqdn: test-connector.london.sandbox.govsvc.uk
 - name: test-intgegration
   fqdn: test-integration-connector.london.sandbox.govsvc.uk
+- name: hub-integration
+  fqdn: www.integration.signin.service.gov.uk
 
 namespaces:
 - name: sandbox-connector-node-metadata


### PR DESCRIPTION
This is need so the VSP can access the Hub metadata.