### PR TITLE
Remove Proxy Node integration namespace

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -35,12 +35,6 @@ namespaces:
   branch: sandbox
   path: ci/sandbox
   requiredApprovalCount: 0
-- name: sandbox-proxy-node-integration
-  owner: alphagov
-  repository: verify-proxy-node
-  branch: master
-  path: ci/sandbox
-  requiredApprovalCount: 0
 - name: spike-dcs-mtls
 - name: sandbox-aws-service-operator-test
   roles:


### PR DESCRIPTION
We don't really need two Sandbox namespaces now that we have the dev namespace that we can deploy anything to.
