### PR TITLE
Deploy VMC to Sandbox from a separate pipeline than the Verify cluster

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -26,7 +26,7 @@ namespaces:
   owner: alphagov
   repository: verify-metadata-controller
   branch: sandbox
-  path: ci
+  path: ci/sandbox
   requiredApprovalCount: 0
   scope: cluster
 - name: sandbox-proxy-node-dev


### PR DESCRIPTION
We don't want the Sandbox instance to publish real releases to Github. There need to be two pipelines, just like for the Proxy Node.

This needs to be merged with alphagov/verify-cluster-config#42