### PR TITLE
EID-1823 Add hostname of new multi-country stub-connector

### DIFF
--- a/clusters/sandbox-values.yaml
+++ b/clusters/sandbox-values.yaml
@@ -18,7 +18,11 @@ egressSafelist:
     resolution: DNS
 - name: verify-connector-sandbox
   service:
-    hosts: ["test-connector.london.sandbox.govsvc.uk"]
+    hosts:
+      # legacy sandbox stub-connector
+      - test-connector.london.sandbox.govsvc.uk
+      # multi-country stub-connector
+      - stub-connector.eidas.test.london.sandbox.govsvc.uk
     ports:
     - name: https
       number: 443


### PR DESCRIPTION
Add hostname `stub-connector.eidas.test.london.sandbox.govsvc.uk` to sandbox cluster egress safelist.